### PR TITLE
feat: Add DialogInStepper component

### DIFF
--- a/src/components/DialogInStepper/DialogInStepper.jsx
+++ b/src/components/DialogInStepper/DialogInStepper.jsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import cx from 'classnames'
+
+import {
+  useCozyDialog,
+  DialogBackButton,
+  DialogCloseButton
+} from 'cozy-ui/transpiled/react/CozyDialogs'
+import MUIDialog, {
+  DialogTitle,
+  DialogContent
+} from 'cozy-ui/transpiled/react/Dialog'
+import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
+
+const DialogInStepper = props => {
+  const { onClose, title, content } = props
+  const { dialogProps, dialogTitleProps, fullScreen, id } = useCozyDialog(props)
+
+  return (
+    <MUIDialog {...dialogProps}>
+      {!fullScreen && onClose && (
+        <DialogCloseButton
+          onClick={onClose}
+          data-test-id={`modal-close-button-${id}`}
+        />
+      )}
+      <DialogTitle
+        {...dialogTitleProps}
+        className={cx('u-ellipsis', { dialogTitleFull: !onClose })}
+      >
+        {fullScreen && onClose && <DialogBackButton onClick={onClose} />}
+        {title}
+      </DialogTitle>
+      <Divider />
+      <DialogContent classes={{ root: 'actionsInContent' }}>
+        {content}
+      </DialogContent>
+    </MUIDialog>
+  )
+}
+
+DialogInStepper.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func,
+  title: PropTypes.node,
+  content: PropTypes.node,
+  size: PropTypes.oneOf(['small', 'medium', 'large'])
+}
+
+export default DialogInStepper

--- a/src/components/DialogInStepper/index.jsx
+++ b/src/components/DialogInStepper/index.jsx
@@ -1,0 +1,1 @@
+export { default as DialogInStepper } from './DialogInStepper'

--- a/src/components/DialogInStepper/styles.styl
+++ b/src/components/DialogInStepper/styles.styl
@@ -1,0 +1,5 @@
+.actionsInContent
+    display flex
+    flex-direction column
+    justify-content space-between
+    padding 0 1rem

--- a/src/styles/index.styl
+++ b/src/styles/index.styl
@@ -1,5 +1,6 @@
 @require 'components/table.styl'
 @require '../components/CompositeHeader/styles.styl'
+@require '../components/DialogInStepper/styles.styl'
 
 [role=banner] .coz-bar-container
     +small-screen()


### PR DESCRIPTION
Nous devons implémenter une modale type `CozyDialog`, mais dans le contexte d'un Stepper.
Nous avons besoin de lui passer un composant ayant son contenu et ses actions plutôt que de devoir séparer les deux.
Le contenu étant dynamique, nous ne pouvons pas avoir des actions séparées, ces dernières seront à chaque step dépendantes du contenu.