### PR TITLE
feat: Add HomeWrapper component

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -10,7 +10,7 @@ import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
-import Home from './Home'
+import { HomeWrapper } from './HomeWrapper'
 
 export const App = () => {
   const client = useClient()
@@ -30,7 +30,7 @@ export const App = () => {
         <Main>
           <Content className="app-content">
             <Switch>
-              <Route path="/" component={Home} />
+              <Route path="/" component={HomeWrapper} />
               <Redirect from="*" to="/" />
             </Switch>
           </Content>

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -1,36 +1,21 @@
-import React, { useContext } from 'react'
+import React from 'react'
 
-import { useQuery, isQueryLoading } from 'cozy-client'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Empty } from 'cozy-ui/transpiled/react'
 import Fab from 'cozy-ui/transpiled/react/Fab'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import PlusIcon from 'cozy-ui/transpiled/react/Icons/Plus'
-import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
-import { getAllPapers } from '../../utils/queries'
 import { PapersList } from '../Papers'
 import { PlaceholdersList } from '../Placeholders'
-import { DialogModalContext } from '../Contexts'
-import Stepper from '../Stepper'
 import HomeCloud from '../../assets/icons/HomeCloud.svg'
 
-const Home = () => {
+const Home = ({ data }) => {
   const { t } = useI18n()
-  const { isDialogModalOpen } = useContext(DialogModalContext)
-  const { data, ...rest } = useQuery(
-    getAllPapers.definition,
-    getAllPapers.options
-  )
 
   return (
     <>
-      {isQueryLoading(rest) ? (
-        <Spinner
-          size="xxlarge"
-          className="u-flex u-flex-justify-center u-mt-2 u-h-5"
-        />
-      ) : data && data.length === 0 ? (
+      {data.length === 0 ? (
         <Empty
           icon={HomeCloud}
           title={t('Home.Empty.title')}
@@ -38,9 +23,9 @@ const Home = () => {
           layout={false}
         />
       ) : (
-        <PapersList papers={data || []} />
+        <PapersList papers={data} />
       )}
-      <PlaceholdersList papers={data || []} />
+      <PlaceholdersList papers={data} />
       <Fab
         color="primary"
         aria-label="add"
@@ -49,8 +34,6 @@ const Home = () => {
       >
         <Icon icon={PlusIcon} />
       </Fab>
-
-      {isDialogModalOpen && <Stepper />}
     </>
   )
 }

--- a/src/components/HomeWrapper/HomeWrapper.jsx
+++ b/src/components/HomeWrapper/HomeWrapper.jsx
@@ -1,0 +1,32 @@
+import React, { useContext } from 'react'
+
+import { useQuery, isQueryLoading } from 'cozy-client'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+
+import { getAllPapers } from '../../utils/queries'
+import { DialogModalContext } from '../Contexts'
+import Stepper from '../Stepper'
+import Home from '../Home'
+
+const HomeWrapper = () => {
+  const { isDialogModalOpen } = useContext(DialogModalContext)
+  const { data, ...rest } = useQuery(
+    getAllPapers.definition,
+    getAllPapers.options
+  )
+
+  return !isDialogModalOpen ? (
+    isQueryLoading(rest) ? (
+      <Spinner
+        size="xxlarge"
+        className="u-flex u-flex-justify-center u-mt-2 u-h-5"
+      />
+    ) : (
+      <Home data={data || []} />
+    )
+  ) : (
+    <Stepper />
+  )
+}
+
+export default HomeWrapper

--- a/src/components/HomeWrapper/index.jsx
+++ b/src/components/HomeWrapper/index.jsx
@@ -1,0 +1,1 @@
+export { default as HomeWrapper } from './HomeWrapper'

--- a/src/components/ImportDropdown/ImportDropdown.jsx
+++ b/src/components/ImportDropdown/ImportDropdown.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useState, useContext, useEffect } from 'react'
 import PropTypes from 'prop-types'
 
 import { useClient } from 'cozy-client'
@@ -19,6 +19,8 @@ import Konnector from '../../assets/icons/Konnectors.svg'
 const ImportDropdown = ({ label, icon }) => {
   const { t } = useI18n()
   const client = useClient()
+  const [showModal, setShowModal] = useState(false)
+
   const { setIsDialogModalOpen, setDialogModalLabel } = useContext(
     DialogModalContext
   )
@@ -27,10 +29,17 @@ const ImportDropdown = ({ label, icon }) => {
     window.location = getFilteredStoreUrl(client)
   }
 
-  const showModal = () => {
-    setIsDialogModalOpen(true)
-    setDialogModalLabel(label)
-  }
+  // Avoid a potential memory leak.
+  // When calling "setIsDialogModalOpen" to "true", "Home" is unmounted to be replaced by the "Stepper".
+  // The "onClose" callback of "ActionMenu" in the "Placeholder" is unmounted during the process and causes a memory leak.
+  useEffect(() => {
+    return () => {
+      if (showModal) {
+        setIsDialogModalOpen(true)
+        setDialogModalLabel(label)
+      }
+    }
+  })
 
   return (
     <>
@@ -57,7 +66,7 @@ const ImportDropdown = ({ label, icon }) => {
           ellipsis={false}
         />
       </ListItem>
-      <ListItem onClick={showModal}>
+      <ListItem onClick={() => setShowModal(true)}>
         <ListItemIcon>
           <Icon icon={Camera} size={16} />
         </ListItemIcon>


### PR DESCRIPTION
Fait directement suite à https://github.com/cozy/mespapiers/pull/7

Pour éviter de futurs problèmes avec le realtime.
Ajout d'un wrapper au-dessus du composant `Home` pour faire le switch entre les listes de papiers/placeholders et la modal de création.