### PR TITLE
feat: Update papers definitions

### DIFF
--- a/src/components/Contexts/StepperDialogProvider.jsx
+++ b/src/components/Contexts/StepperDialogProvider.jsx
@@ -1,30 +1,43 @@
-import React, { createContext, useCallback, useState } from 'react'
+import React, { createContext, useCallback, useEffect, useState } from 'react'
 
 const StepperDialogContext = createContext()
 
 const StepperDialogProvider = ({ children }) => {
   const [isStepperDialogOpen, setIsStepperDialogOpen] = useState(false)
   const [stepperDialogTitle, setStepperDialogTitle] = useState('')
+  const [allCurrentPagesDefinitions, setAllCurrentPagesDefinitions] = useState(
+    []
+  )
   const [allCurrentPages, setAllCurrentPages] = useState([])
-  const [currentPage, setCurrentPage] = useState(1)
+  const [currentPageIndex, setCurrentPageIndex] = useState(1)
+
+  useEffect(() => {
+    if (allCurrentPagesDefinitions.length > 0) {
+      const allCurrentPagesDefinitionsSorted = allCurrentPagesDefinitions.sort(
+        (a, b) => a.pageIndex - b.pageIndex
+      )
+      setAllCurrentPages(allCurrentPagesDefinitionsSorted)
+    }
+  }, [allCurrentPagesDefinitions])
 
   const previousPage = useCallback(() => {
-    currentPage > 1
-      ? setCurrentPage(prev => prev - 1)
+    currentPageIndex > 1
+      ? setCurrentPageIndex(prev => prev - 1)
       : setIsStepperDialogOpen(false)
-  }, [currentPage])
+  }, [currentPageIndex])
 
   const nextPage = useCallback(() => {
-    allCurrentPages.length > currentPage && setCurrentPage(prev => prev + 1)
-  }, [currentPage, allCurrentPages.length])
+    allCurrentPages.length > currentPageIndex &&
+      setCurrentPageIndex(prev => prev + 1)
+  }, [allCurrentPages.length, currentPageIndex])
 
   const stepperDialog = {
     isStepperDialogOpen,
     allCurrentPages,
-    currentPage,
+    currentPageIndex,
     stepperDialogTitle,
     setIsStepperDialogOpen,
-    setAllCurrentPages,
+    setAllCurrentPagesDefinitions,
     setStepperDialogTitle,
     previousPage,
     nextPage

--- a/src/components/Placeholders/Placeholder.jsx
+++ b/src/components/Placeholders/Placeholder.jsx
@@ -22,7 +22,7 @@ const Placeholder = ({ placeholder, divider }) => {
   const { t } = useI18n()
   const [isDrawerDisplayed, setIsDrawerDisplayed] = useState(false)
   const {
-    setAllCurrentPages,
+    setAllCurrentPagesDefinitions,
     setStepperDialogTitle
   } = useStepperDialogContext()
 
@@ -33,11 +33,11 @@ const Placeholder = ({ placeholder, divider }) => {
     if (formModel) {
       // Set Dialog modal
       setStepperDialogTitle(formModel.label)
-      setAllCurrentPages(formModel.pages)
+      setAllCurrentPagesDefinitions(formModel.pages)
       // Set ActionMenu
       setIsDrawerDisplayed(true)
     }
-  }, [placeholder.label, setAllCurrentPages, setStepperDialogTitle])
+  }, [placeholder.label, setAllCurrentPagesDefinitions, setStepperDialogTitle])
   const hideDrawer = useCallback(() => setIsDrawerDisplayed(false), [])
 
   return (

--- a/src/components/StepperDialogWrapper/StepperDialogWrapper.jsx
+++ b/src/components/StepperDialogWrapper/StepperDialogWrapper.jsx
@@ -3,17 +3,14 @@ import React from 'react'
 import { useStepperDialogContext } from '../Hooks'
 
 const StepperDialogWrapper = () => {
-  const { allCurrentPages, currentPage } = useStepperDialogContext()
+  const { allCurrentPages, currentPageIndex } = useStepperDialogContext()
 
-  return allCurrentPages.map((page, i) => (
-    <React.Fragment key={i}>
-      {page.pageNumber === currentPage && (
-        <>
-          {/* <StepperDialog ... title={via StepperDialogContext} content={<LazyLoad currentPage={page} />} ... */}
-        </>
-      )}
-    </React.Fragment>
-  ))
+  return allCurrentPages.map(
+    page =>
+      page.pageIndex === currentPageIndex && (
+        <React.Fragment key={page.pageIndex}></React.Fragment>
+      )
+  )
 }
 
 export default StepperDialogWrapper

--- a/src/constants/papersDefinitions.json
+++ b/src/constants/papersDefinitions.json
@@ -4,20 +4,26 @@
       "label": "national_id_card",
       "icon": "people",
       "featuredPlaceholder": true,
-      "rankPlaceholder": 1,
+      "placeholderIndex": 1,
       "pages": [
         {
-          "pageNumber": 1,
+          "pageIndex": 1,
+          "occurrence": 1,
+          "model": "upload",
           "illustration": "illu_id_card_recto.svg",
           "text": "PaperJSON.IDCard.page01.text"
         },
         {
-          "pageNumber": 2,
+          "pageIndex": 2,
+          "occurrence": 2,
+          "model": "upload",
           "illustration": "illu_id_card_verso.svg",
           "text": "PaperJSON.IDCard.page02.text"
         },
         {
-          "pageNumber": 3,
+          "pageIndex": 3,
+          "occurrence": 1,
+          "model": "information",
           "illustration": "illu_id_card_number.svg",
           "text": "PaperJSON.IDCard.page03.text",
           "attributes": [
@@ -28,7 +34,9 @@
           ]
         },
         {
-          "pageNumber": 4,
+          "pageIndex": 4,
+          "occurrence": 1,
+          "model": "information",
           "illustration": "illu_id_card_peremptionDate.svg",
           "text": "PaperJSON.IDCard.page04.text",
           "attributes": [
@@ -45,21 +53,24 @@
     {
       "label": "passport",
       "icon": "people",
-      "featuredPlaceholder": false,
-      "rankPlaceholder": 2,
+      "featuredPlaceholder": true,
+      "placeholderIndex": 2,
       "pages": [
         {
-          "pageNumber": 1,
+          "pageIndex": 1,
+          "occurrence": 2,
           "illustration": "illu_passport_recto.svg",
           "text": "PaperJSON.Passport.page01.text"
         },
         {
-          "pageNumber": 2,
+          "pageIndex": 2,
+          "occurrence": 1,
           "illustration": "illu_passport_verso.svg",
           "text": "PaperJSON.Passport.page02.text"
         },
         {
-          "pageNumber": 3,
+          "pageIndex": 3,
+          "occurrence": 3,
           "illustration": "illu_passport_number.svg",
           "text": "PaperJSON.Passport.page03.text",
           "attributes": [
@@ -70,7 +81,8 @@
           ]
         },
         {
-          "pageNumber": 4,
+          "pageIndex": 4,
+          "occurrence": 1,
           "illustration": "illu_passport_peremptionDate.svg",
           "text": "PaperJSON.Passport.page04.text",
           "attributes": [

--- a/src/utils/getPlaceholders.js
+++ b/src/utils/getPlaceholders.js
@@ -2,12 +2,44 @@ import get from 'lodash/get'
 
 import papersJSON from '../constants/papersDefinitions.json'
 
-export const getPlaceholders = (papers = []) => {
-  return papersJSON.papersDefinitions.filter(
-    paperDefinition =>
-      !papers.some(
-        paper =>
-          get(paper, 'metadata.qualification.label') === paperDefinition.label
-      ) && paperDefinition.featuredPlaceholder
-  )
-}
+/**
+ * @typedef {Object} PageAttributes
+ * @property {string} name - Name of the attribute.
+ * @property {string} type - Type of the attribute.
+ */
+/**
+ * @typedef {Object} Page
+ * @property {number} pageIndex - Position of the page.
+ * @property {number} occurrence - Number of occurrence for this page.
+ * @property {string} illustration - Name of the illustration.
+ * @property {string} text - Text of the page.
+ * @property {PageAttributes[]} attributes - Array of the attributes.
+ */
+/**
+ * @typedef {Object} Paper
+ * @property {string} label - Label of Paper.
+ * @property {string} icon - Icon of Paper.
+ * @property {boolean} featuredPlaceholder - Is visible on the Homepage.
+ * @property {number} placeholderIndex - Position on the Placeholder list.
+ * @property {Page[]} pages - Array of pages.
+ * @property {string} featureDate - Reference the attribute "name" to be used as main date.
+ * @property {number} maxDisplay - Number of document beyond which a "see more" button is displayed.
+ */
+
+/**
+ * Filters and sorts the list of PlaceHolders
+ * @param {Paper[]} papers Array of Papers
+ * @returns an array of Papers filtered with the prop "featuredPlaceholder",
+ * which does not already exist in DB and
+ * which sorted with the prop "placeholderIndex"
+ */
+export const getPlaceholders = (papers = []) =>
+  papersJSON.papersDefinitions
+    .filter(
+      paperDefinition =>
+        !papers.some(
+          paper =>
+            get(paper, 'metadata.qualification.label') === paperDefinition.label
+        ) && paperDefinition.featuredPlaceholder
+    )
+    .sort((a, b) => a.placeholderIndex - b.placeholderIndex)

--- a/src/utils/getPlaceholders.spec.js
+++ b/src/utils/getPlaceholders.spec.js
@@ -14,11 +14,11 @@ describe('getPlaceholders', () => {
   it('should return correct list of placeholders whitout param', () => {
     const placeholders = getPlaceholders()
 
-    expect(placeholders).toHaveLength(1)
+    expect(placeholders).toHaveLength(2)
   })
   it('should return correct list of placeholders with param', () => {
     const placeholders = getPlaceholders(fakePapers)
 
-    expect(placeholders).toHaveLength(0)
+    expect(placeholders).toHaveLength(1)
   })
 })


### PR DESCRIPTION
Mise à jour du fichier JSON `paperDefinition` et des fichiers qui l'utilisent.

La modification majeur permet d'ajouter dynamiquement des pages dans le parcours si l'occurrence de celle-ci est supérieur à 1.
Ajout également de la prise en compte de l'ordre de la liste des placeholders