### PR TITLE
feat: Add alias import

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -1,0 +1,4 @@
+module.exports = [
+  require('cozy-scripts/config/webpack.bundle.default'),
+  require('./config/webpack.config.mespapiers')
+]

--- a/config/webpack.config.mespapiers.js
+++ b/config/webpack.config.mespapiers.js
@@ -1,0 +1,18 @@
+const path = require(`path`)
+const SRC_DIR = path.resolve(__dirname, '../src')
+const TEST_DIR = path.resolve(__dirname, '../test')
+
+module.exports = {
+  resolve: {
+    alias: {
+      // For autocompletion, remember to inform the "jsconfig.json" file in the project root
+      // For tests, remember to inform the "jest.config.js" file in the project root
+      root: SRC_DIR,
+      components: path.resolve(SRC_DIR, './components'),
+      utils: path.resolve(SRC_DIR, './utils'),
+      assets: path.resolve(SRC_DIR, './assets'),
+      constants: path.resolve(SRC_DIR, './constants'),
+      test: TEST_DIR
+    }
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
     '\\.(png|gif|jpe?g|svg)$': '<rootDir>/test/__mocks__/fileMock.js',
     // identity-obj-proxy module is installed by cozy-scripts
     '.styl$': 'identity-obj-proxy',
-    '^cozy-client$': 'cozy-client/dist/index'
+    '^cozy-client$': 'cozy-client/dist/index',
+    '^root/(.*)': '<rootDir>/src/$1',
+    '^components/(.*)': '<rootDir>/src/components/$1',
+    '^utils/(.*)': '<rootDir>/src/utils/$1',
+    '^assets/(.*)': '<rootDir>/src/assets/$1',
+    '^constants/(.*)': '<rootDir>/src/constants/$1',
+    '^test/(.*)': '<rootDir>/test/$1'
   },
   transformIgnorePatterns: ['node_modules/(?!cozy-ui)'],
   globals: {

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "root/*": ["./src/*"],
+      "components/*": ["./src/components/*"],
+      "utils/*": ["./src/utils/*"],
+      "assets/*": ["./src/assets/*"],
+      "constants/*": ["./src/constants/*"],
+      "test/*": ["./test/*"]
+    }
+  },
+  "exclude": ["node_modules", "build"]
+}

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -10,7 +10,7 @@ import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
-import { HomeWrapper } from './HomeWrapper'
+import { HomeWrapper } from 'components/HomeWrapper'
 
 export const App = () => {
   const client = useClient()

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -6,9 +6,9 @@ import Fab from 'cozy-ui/transpiled/react/Fab'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import PlusIcon from 'cozy-ui/transpiled/react/Icons/Plus'
 
-import { PapersList } from '../Papers'
-import { PlaceholdersList } from '../Placeholders'
-import HomeCloud from '../../assets/icons/HomeCloud.svg'
+import { PapersList } from 'components/Papers'
+import { PlaceholdersList } from 'components/Placeholders'
+import HomeCloud from 'assets/icons/HomeCloud.svg'
 
 const Home = ({ data }) => {
   const { t } = useI18n()

--- a/src/components/Home/Home.spec.jsx
+++ b/src/components/Home/Home.spec.jsx
@@ -2,9 +2,9 @@
 import React from 'react'
 import { render, waitFor } from '@testing-library/react'
 
-import AppLike from '../../../test/components/AppLike'
-import Home from './Home'
-import { fakeData } from './__mocks__/fakeData'
+import AppLike from 'test/components/AppLike'
+import Home from 'components/Home'
+import { fakeData } from 'components/Home/__mocks__/fakeData'
 
 const setup = (data = []) => {
   return render(

--- a/src/components/HomeWrapper/HomeWrapper.jsx
+++ b/src/components/HomeWrapper/HomeWrapper.jsx
@@ -3,10 +3,10 @@ import React from 'react'
 import { useQuery, isQueryLoading } from 'cozy-client'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
-import { getAllPapers } from '../../utils/queries'
-import { useStepperDialogContext } from '../Hooks'
-import { StepperDialogWrapper } from '../StepperDialogWrapper'
-import Home from '../Home'
+import { getAllPapers } from 'utils/queries'
+import { useStepperDialogContext } from 'components/Hooks'
+import { StepperDialogWrapper } from 'components/StepperDialogWrapper'
+import Home from 'components/Home'
 
 const HomeWrapper = () => {
   const { isStepperDialogOpen } = useStepperDialogContext()

--- a/src/components/Hooks/useStepperDialogContext.jsx
+++ b/src/components/Hooks/useStepperDialogContext.jsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react'
-import { StepperDialogContext } from '../Contexts'
+import { StepperDialogContext } from 'components/Contexts'
 
 export const useStepperDialogContext = () => {
   const stepperDialogContext = useContext(StepperDialogContext)

--- a/src/components/ImportDropdown/ImportDropdown.jsx
+++ b/src/components/ImportDropdown/ImportDropdown.jsx
@@ -12,9 +12,9 @@ import IconStack from 'cozy-ui/transpiled/react/IconStack'
 import FileDuotoneIcon from 'cozy-ui/transpiled/react/Icons/FileDuotone'
 import Camera from 'cozy-ui/transpiled/react/Icons/Camera'
 
-import { useStepperDialogContext } from '../Hooks'
-import { getFilteredStoreUrl } from '../../utils/getFilteredStoreUrl'
-import Konnector from '../../assets/icons/Konnectors.svg'
+import { useStepperDialogContext } from 'components/Hooks'
+import { getFilteredStoreUrl } from 'utils/getFilteredStoreUrl'
+import Konnector from 'assets/icons/Konnectors.svg'
 
 const ImportDropdown = ({ label, icon }) => {
   const { t } = useI18n()

--- a/src/components/ImportDropdown/ImportDropdown.spec.jsx
+++ b/src/components/ImportDropdown/ImportDropdown.spec.jsx
@@ -3,8 +3,9 @@ import React from 'react'
 import { render } from '@testing-library/react'
 
 import People from 'cozy-ui/transpiled/react/Icons/People'
-import AppLike from '../../../test/components/AppLike'
-import ImportDropdown from './ImportDropdown'
+
+import AppLike from 'test/components/AppLike'
+import ImportDropdown from 'components/ImportDropdown'
 
 const setup = (label = 'national_id_card') => {
   return render(

--- a/src/components/LazyLoad/LazyLoad.jsx
+++ b/src/components/LazyLoad/LazyLoad.jsx
@@ -1,9 +1,9 @@
 import React, { Suspense, useMemo, useEffect, memo, lazy } from 'react'
+import capitalize from 'lodash/capitalize'
 
 import log from 'cozy-logger'
 
-import { useStepperDialogContext } from '../Hooks'
-import capitalize from 'lodash/capitalize'
+import { useStepperDialogContext } from 'components/Hooks'
 
 const LazyLoadError = err => {
   const { setIsStepperDialogOpen } = useStepperDialogContext()

--- a/src/components/Papers/PapersList.jsx
+++ b/src/components/Papers/PapersList.jsx
@@ -5,7 +5,7 @@ import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
 import ListSubheader from 'cozy-ui/transpiled/react/MuiCozyTheme/ListSubheader'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
-import { Paper } from '.'
+import { Paper } from 'components/Papers'
 
 const PapersList = ({ papers }) => {
   const { t } = useI18n()

--- a/src/components/Placeholders/Placeholder.jsx
+++ b/src/components/Placeholders/Placeholder.jsx
@@ -12,9 +12,9 @@ import FileDuotoneIcon from 'cozy-ui/transpiled/react/Icons/FileDuotone'
 import Plus from 'cozy-ui/transpiled/react/Icons/Plus'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
-import ImportDropdown from '../ImportDropdown'
-import papersJSON from '../../constants/papersDefinitions.json'
-import { useStepperDialogContext } from '../Hooks'
+import ImportDropdown from 'components/ImportDropdown'
+import { useStepperDialogContext } from 'components/Hooks'
+import papersJSON from 'constants/papersDefinitions.json'
 
 const papers = papersJSON.papersDefinitions
 

--- a/src/components/Placeholders/Placeholder.spec.jsx
+++ b/src/components/Placeholders/Placeholder.spec.jsx
@@ -2,9 +2,9 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 
-import AppLike from '../../../test/components/AppLike'
-import Placeholder from './Placeholder'
-import paperJSON from '../../constants/papersDefinitions.json'
+import AppLike from 'test/components/AppLike'
+import { Placeholder } from 'components/Placeholders'
+import paperJSON from 'constants/papersDefinitions.json'
 const papersList = paperJSON.papersDefinitions
 
 const setup = (placeholder = papersList[0]) => {

--- a/src/components/Placeholders/PlaceholdersList.jsx
+++ b/src/components/Placeholders/PlaceholdersList.jsx
@@ -4,8 +4,8 @@ import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
 import ListSubheader from 'cozy-ui/transpiled/react/MuiCozyTheme/ListSubheader'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
-import { Placeholder } from '.'
-import { getPlaceholders } from '../../utils/getPlaceholders'
+import { Placeholder } from 'components/Placeholders'
+import { getPlaceholders } from 'utils/getPlaceholders'
 
 const PlaceholdersList = ({ papers }) => {
   const { t } = useI18n()

--- a/src/components/Placeholders/PlaceholdersList.spec.jsx
+++ b/src/components/Placeholders/PlaceholdersList.spec.jsx
@@ -2,8 +2,8 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 
-import AppLike from '../../../test/components/AppLike'
-import PlaceholdersList from './PlaceholdersList'
+import AppLike from 'test/components/AppLike'
+import { PlaceholdersList } from 'components/Placeholders'
 
 const fakePapers = [
   {

--- a/src/components/StepperDialogWrapper/StepperDialogWrapper.jsx
+++ b/src/components/StepperDialogWrapper/StepperDialogWrapper.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { useStepperDialogContext } from '../Hooks'
+import { useStepperDialogContext } from 'components/Hooks'
 
 const StepperDialogWrapper = () => {
   const { allCurrentPages, currentPage } = useStepperDialogContext()

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -15,9 +15,9 @@ import { I18n } from 'cozy-ui/transpiled/react/I18n'
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
-import setupApp from './setupApp'
-import App from '../../components/App'
-import { StepperDialogProvider } from '../../components/Contexts'
+import setupApp from 'root/targets/browser/setupApp'
+import App from 'components/App'
+import { StepperDialogProvider } from 'components/Contexts'
 
 /*
 With MUI V4, it is possible to generate deterministic class names.

--- a/src/targets/browser/setupApp.jsx
+++ b/src/targets/browser/setupApp.jsx
@@ -2,8 +2,8 @@ import memoize from 'lodash/memoize'
 
 import { initTranslation } from 'cozy-ui/transpiled/react/I18n'
 
-import { getClient } from '../../utils/client'
-import { getValues, initBar } from '../../utils/bar'
+import { getClient } from 'utils/client'
+import { getValues, initBar } from 'utils/bar'
 
 /**
  * Memoize this function in its own file so that it is correctly memoized

--- a/src/utils/bar.js
+++ b/src/utils/bar.js
@@ -11,7 +11,7 @@ const getDataOrDefault = (data, defaultData) =>
  */
 export const getValues = ({ app, locale }) => {
   const defaultValues = {
-    appIconDefault: require('../targets/vendor/assets/icon.svg'),
+    appIconDefault: require('root/targets/vendor/assets/icon.svg'),
     appNamePrefixDefault: manifest.name_prefix,
     appNameDefault: manifest.name,
     appLocaleDefault: 'en'

--- a/src/utils/client.js
+++ b/src/utils/client.js
@@ -1,6 +1,6 @@
 import CozyClient from 'cozy-client'
 import manifest from '../../manifest.webapp'
-import schema from '../doctypes'
+import schema from 'root/doctypes'
 
 /**
  * Returns cozy client instance

--- a/src/utils/getFilteredStoreUrl.js
+++ b/src/utils/getFilteredStoreUrl.js
@@ -1,6 +1,6 @@
 import { generateUniversalLink } from 'cozy-ui/transpiled/react/AppLinker'
 
-import { FILES_DOCTYPE } from '../doctypes'
+import { FILES_DOCTYPE } from 'root/doctypes'
 
 export const getFilteredStoreUrl = client =>
   generateUniversalLink({

--- a/src/utils/getFilteredStoreUrl.spec.js
+++ b/src/utils/getFilteredStoreUrl.spec.js
@@ -1,6 +1,6 @@
 import { createMockClient } from 'cozy-client'
 
-import { getFilteredStoreUrl } from './getFilteredStoreUrl'
+import { getFilteredStoreUrl } from 'utils/getFilteredStoreUrl'
 
 describe('getFilteredStoreUrl', () => {
   it('should return correct store url', () => {

--- a/src/utils/getIconByLabel.spec.js
+++ b/src/utils/getIconByLabel.spec.js
@@ -1,6 +1,6 @@
 import People from 'cozy-ui/transpiled/react/Icons/People'
 
-import { getIconByLabel } from './getIconByLabel'
+import { getIconByLabel } from 'utils/getIconByLabel'
 
 describe('getIconByLabel', () => {
   it('should return correct Icon if label is found', () => {

--- a/src/utils/getPlaceholders.js
+++ b/src/utils/getPlaceholders.js
@@ -1,6 +1,6 @@
 import get from 'lodash/get'
 
-import papersJSON from '../constants/papersDefinitions.json'
+import papersJSON from 'constants/papersDefinitions.json'
 
 export const getPlaceholders = (papers = []) => {
   return papersJSON.papersDefinitions.filter(

--- a/src/utils/getPlaceholders.spec.js
+++ b/src/utils/getPlaceholders.spec.js
@@ -1,4 +1,4 @@
-import { getPlaceholders } from './getPlaceholders'
+import { getPlaceholders } from 'utils/getPlaceholders'
 
 const fakePapers = [
   {

--- a/src/utils/queries.js
+++ b/src/utils/queries.js
@@ -1,6 +1,6 @@
 import { Q } from 'cozy-client'
 
-import { FILES_DOCTYPE } from '../doctypes'
+import { FILES_DOCTYPE } from 'root/doctypes'
 
 export const getAllPapers = {
   definition: () =>

--- a/test/components/AppLike.jsx
+++ b/test/components/AppLike.jsx
@@ -1,10 +1,12 @@
 import React from 'react'
+import { HashRouter } from 'react-router-dom'
+
 import { CozyProvider, createMockClient } from 'cozy-client'
 import I18n from 'cozy-ui/transpiled/react/I18n'
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
-import { HashRouter } from 'react-router-dom'
-import enLocale from '../../src/locales/en.json'
-import { StepperDialogProvider } from '../../src/components/Contexts'
+
+import { StepperDialogProvider } from 'components/Contexts'
+import enLocale from 'root/locales/en.json'
 
 const AppLike = ({ children, client }) => (
   <CozyProvider client={client || createMockClient({})}>

--- a/test/doctypes/files.spec.js
+++ b/test/doctypes/files.spec.js
@@ -2,7 +2,7 @@
 
 /* eslint-env jest */
 
-import { filesQuery, FILES_DOCTYPE } from 'doctypes'
+import { filesQuery, FILES_DOCTYPE } from 'root/doctypes'
 
 const mockClient = {
   find: jest.fn(),

--- a/test/lib/I18n.js
+++ b/test/lib/I18n.js
@@ -4,7 +4,7 @@ import { I18n } from 'cozy-ui/transpiled/react/I18n'
 
 const I18nComponent = new I18n({
   lang: 'en',
-  dictRequire: lang => require(`../../src/locales/${lang}`)
+  dictRequire: lang => require(`root/locales/${lang}`)
 })
 
 export const mockT = I18nComponent.getChildContext().t


### PR DESCRIPTION
Ajout de la configuration Webpack et Jest pour gérer les imports à base d'alias, ainsi qu'un fichier (`jsconfig.json`) pour continuer à avoir une autocomplétion des chemins d'import. :)
Et repasse sur tous les fichiers avec des imports relatifs.