### PR TITLE
feat: Upgrade CompositeHeader component

### DIFF
--- a/src/components/CompositeHeader/CompositeHeader.jsx
+++ b/src/components/CompositeHeader/CompositeHeader.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, isValidElement } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import './styles.styl'
@@ -7,7 +7,14 @@ import Typography from 'cozy-ui/transpiled/react/Typography'
 import Icon, { iconPropType } from 'cozy-ui/transpiled/react/Icon'
 
 // TODO Test and improve it & PR cozy-ui
-const CompositeHeader = ({ icon, title, text, className, ...restProps }) => {
+const CompositeHeader = ({
+  icon,
+  iconSize,
+  title: Title,
+  text: Text,
+  className,
+  ...restProps
+}) => {
   const [imgScr, setImgSrc] = useState(null)
 
   useEffect(() => {
@@ -25,27 +32,43 @@ const CompositeHeader = ({ icon, title, text, className, ...restProps }) => {
   return (
     <div className={cx('composite-header-container', className)} {...restProps}>
       {imgScr && (
-        <Icon className={'composite-header-img'} icon={imgScr} size="100%" />
+        <Icon
+          className={cx('composite-header-img', {
+            [`composite-header-img--${iconSize}`]: iconSize !== 'normal'
+          })}
+          icon={imgScr}
+          size={'100%'}
+        />
       )}
-      {title && (
-        <Typography gutterBottom variant="h5" color="textPrimary">
-          {title}
-        </Typography>
-      )}
-      {text && (
-        <Typography variant="body1" gutterBottom>
-          {text}
-        </Typography>
-      )}
+      {Title &&
+        (isValidElement(Title) ? (
+          Title
+        ) : (
+          <Typography gutterBottom variant="h5" color="textPrimary">
+            {Title}
+          </Typography>
+        ))}
+      {Text &&
+        (isValidElement(Text) ? (
+          Text
+        ) : (
+          <Typography variant="body1" gutterBottom>
+            {Text}
+          </Typography>
+        ))}
     </div>
   )
 }
 
 CompositeHeader.propTypes = {
   icon: iconPropType,
-  title: PropTypes.node.isRequired,
-  text: PropTypes.node,
+  iconSize: PropTypes.oneOf(['small', 'normal', 'medium', 'large']),
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
+  text: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   className: PropTypes.string
+}
+CompositeHeader.defaultProps = {
+  iconSize: 'normal'
 }
 
 export default CompositeHeader

--- a/src/components/CompositeHeader/styles.styl
+++ b/src/components/CompositeHeader/styles.styl
@@ -7,14 +7,30 @@
     height 100%
     justify-content center
     max-width 100%
-    padding rem(32) 0
     text-align center
 
 .composite-header-img
     display block
+    margin 0 auto rem(16)
+    height rem(128)
+
+    +medium-screen()
+        height rem(96)
+
+.composite-header-img--small
+    height rem(96)
+
+    +medium-screen()
+        height rem(64)
+
+.composite-header-img--medium
     height rem(160)
-    margin  0 auto rem(16)
+
+    +medium-screen()
+        height rem(128)
+
+.composite-header-img--large
+    height rem(192)
 
     +medium-screen()
         height rem(160)
-        margin-bottom rem(8)


### PR DESCRIPTION
Mise à jour du composant `CompositeHeader` :
- Ajout de la prop `IconSize` pour gérer la taille de l'icône
- Ajout de la possibilité de passer des composants aux props `title` & `text`