### PR TITLE
feat: Rework formData

### DIFF
--- a/src/components/Contexts/FormDataProvider.jsx
+++ b/src/components/Contexts/FormDataProvider.jsx
@@ -3,7 +3,11 @@ import React, { createContext, useState } from 'react'
 const FormDataContext = createContext()
 
 const FormDataProvider = ({ children }) => {
-  const [formData, setFormData] = useState({})
+  const [formData, setFormData] = useState({
+    contactId: '',
+    metadata: {},
+    data: {}
+  })
 
   return (
     <FormDataContext.Provider value={{ formData, setFormData }}>

--- a/src/components/ModelSteps/AcquisitionResult.jsx
+++ b/src/components/ModelSteps/AcquisitionResult.jsx
@@ -25,9 +25,15 @@ const AcquisitionResult = ({ file, setFile, currentStep }) => {
   const onValid = () => {
     setFormData(prev => ({
       ...prev,
-      [currentStep.stepIndex]: {
-        file,
-        metadata: null
+      data: {
+        ...prev.data,
+        [currentStep.stepIndex]: {
+          file,
+          fileMetadata: {
+            page: currentStep.page,
+            pageName: currentStep.pageName
+          }
+        }
       }
     }))
     nextStep()

--- a/src/components/ModelSteps/Information.jsx
+++ b/src/components/ModelSteps/Information.jsx
@@ -12,7 +12,7 @@ import InputTextAdapter from 'src/components/ModelSteps/widgets/InputTextAdapter
 
 const Information = ({ currentStep }) => {
   const { t } = useI18n()
-  const { illustration, text, attributes, rel } = currentStep
+  const { illustration, text, attributes } = currentStep
   const { formData, setFormData } = useFormDataContext()
   const { nextStep } = useStepperDialogContext()
   const [value, setValue] = useState({})
@@ -21,7 +21,10 @@ const Information = ({ currentStep }) => {
     if (value) {
       setFormData(prev => ({
         ...prev,
-        [rel]: { ...prev[rel], metadata: value }
+        metadata: {
+          ...prev.metadata,
+          ...value
+        }
       }))
       nextStep()
     }
@@ -32,14 +35,14 @@ const Information = ({ currentStep }) => {
       case 'date':
         return (
           <InputDateAdapter
-            attrs={{ metadata: formData[rel].metadata, name, inputLabel }}
+            attrs={{ metadata: formData.metadata, name, inputLabel }}
             setValue={setValue}
           />
         )
       case 'frenchIdCardNumber':
         return (
           <InputTextAdapter
-            attrs={{ metadata: formData[rel].metadata, name, inputLabel }}
+            attrs={{ metadata: formData.metadata, name, inputLabel }}
             setValue={setValue}
           />
         )

--- a/src/components/ModelSteps/widgets/InputDateAdapter.jsx
+++ b/src/components/ModelSteps/widgets/InputDateAdapter.jsx
@@ -27,7 +27,7 @@ const InputDateAdapter = ({ attrs, setValue }) => {
   const classes = useStyles()
   const [locales, setLocales] = useState('')
   const [selectedDate, handleDateChange] = useState(
-    metadata ? metadata[name] : new Date()
+    metadata[name] || new Date()
   )
 
   useEffect(() => {

--- a/src/components/ModelSteps/widgets/InputTextAdapter.jsx
+++ b/src/components/ModelSteps/widgets/InputTextAdapter.jsx
@@ -6,7 +6,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 const InputTextAdapter = ({ attrs, setValue }) => {
   const { name, inputLabel, metadata } = attrs
   const { t } = useI18n()
-  const [value, setState] = useState(metadata ? metadata[name] : '')
+  const [value, setState] = useState(metadata[name] || '')
 
   useEffect(() => {
     setValue(prev => ({ ...prev, [name]: value }))

--- a/src/constants/papersDefinitions.json
+++ b/src/constants/papersDefinitions.json
@@ -10,7 +10,7 @@
           "stepIndex": 1,
           "model": "scan",
           "page": "recto",
-          "pageName": "PaperJSON.IDCard.step01.pageName",
+          "pageName": "PaperJSON.IDCard.pageName.recto",
           "illustration": "IlluIdCardRecto.svg",
           "text": "PaperJSON.IDCard.step01.text"
         },
@@ -18,7 +18,7 @@
           "stepIndex": 2,
           "model": "scan",
           "page": "verso",
-          "pageName": "PaperJSON.IDCard.step02.pageName",
+          "pageName": "PaperJSON.IDCard.pageName.verso",
           "illustration": "IlluIdCardVerso.svg",
           "text": "PaperJSON.IDCard.step02.text"
         },
@@ -27,7 +27,6 @@
           "model": "information",
           "illustration": "IlluIdCardRectoHelp.svg",
           "text": "PaperJSON.IDCard.step03.text",
-          "rel": 1,
           "attributes": [
             {
               "name": "number",
@@ -41,7 +40,6 @@
           "model": "information",
           "illustration": "IlluIdCardVersoHelp.svg",
           "text": "PaperJSON.IDCard.step04.text",
-          "rel": 2,
           "attributes": [
             {
               "name": "peremptionDate",
@@ -82,7 +80,6 @@
           "model": "information",
           "illustration": "IlluIdCardRectoHelp.svg",
           "text": "PaperJSON.Passport.step03.text",
-          "rel": 1,
           "attributes": [
             {
               "name": "number",
@@ -96,7 +93,6 @@
           "model": "information",
           "illustration": "IlluIdCardVersoHelp.svg",
           "text": "PaperJSON.Passport.step04.text",
-          "rel": 2,
           "attributes": [
             {
               "name": "peremptionDate",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -35,6 +35,10 @@
   },
   "PaperJSON": {
     "IDCard": {
+      "pageName": {
+        "recto": "Front side",
+        "verso": "Back side"
+      },
       "step01": {
         "text": "Take a picture of the front of your ID card"
       },
@@ -51,6 +55,10 @@
       }
     },
     "Passport": {
+      "pageName": {
+        "recto": "TODO Passport recto",
+        "verso": "TODO Passport verso"
+      },
       "step01": {
         "text": "TODO Passport01"
       },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -35,6 +35,10 @@
   },
   "PaperJSON": {
     "IDCard": {
+      "pageName": {
+        "recto": "Face avant",
+        "verso": "Face arrière"
+      },
       "step01": {
         "text": "Photographier la face avant de votre carte d’identité"
       },
@@ -51,6 +55,10 @@
       }
     },
     "Passport": {
+      "pageName": {
+        "recto": "TODO Passport recto",
+        "verso": "TODO Passport verso"
+      },
       "step01": {
         "text": "TODO Passport01"
       },


### PR DESCRIPTION
Refacto du state `formData` pour convenir au nouveau besoin.

Ex: En fin de process, nous voulons pouvoir enregistrer chaque fichier avec leur propre `fileMetadata` (`page` & `pageName`), les `metadata` générales et le `contact`