### PR TITLE
fix: Reset StepperProvider correctly on close

### DIFF
--- a/src/components/Contexts/StepperDialogProvider.jsx
+++ b/src/components/Contexts/StepperDialogProvider.jsx
@@ -11,6 +11,15 @@ const StepperDialogProvider = ({ children }) => {
   const [currentDefinition, setCurrentDefinition] = useState(null)
 
   useEffect(() => {
+    if (!isStepperDialogOpen) {
+      setCurrentDefinition(null)
+      setStepperDialogTitle('')
+      setAllCurrentSteps([])
+      setCurrentStepIndex(1)
+    }
+  }, [isStepperDialogOpen])
+
+  useEffect(() => {
     if (currentDefinition) {
       setStepperDialogTitle(currentDefinition.label)
       const allCurrentStepsDefinitions = currentDefinition.steps


### PR DESCRIPTION
Fix to make sure that all the states of the StepperDialogProvider are well reset at the closing of the latter.
Otherwise, the second time a paper is created, it starts at the last step of the previous paper.