### PR TITLE
feat: Add PapersDefinition & refactor

### DIFF
--- a/src/components/Contexts/StepperDialogProvider.jsx
+++ b/src/components/Contexts/StepperDialogProvider.jsx
@@ -22,7 +22,7 @@ const StepperDialogProvider = ({ children }) => {
   useEffect(() => {
     if (currentDefinition) {
       setStepperDialogTitle(currentDefinition.label)
-      const allCurrentStepsDefinitions = currentDefinition.steps
+      const allCurrentStepsDefinitions = currentDefinition.acquisitionSteps
       if (allCurrentStepsDefinitions.length > 0) {
         const allCurrentStepsDefinitionsSorted = allCurrentStepsDefinitions.sort(
           (a, b) => a.stepIndex - b.stepIndex

--- a/src/components/ModelSteps/Information.jsx
+++ b/src/components/ModelSteps/Information.jsx
@@ -40,17 +40,10 @@ const Information = ({ currentStep }) => {
             setValue={setValue}
           />
         )
-      case 'frenchIdCardNumber':
+      default:
         return (
           <InputTextAdapter
-            attrs={{ metadata: formData.metadata, name, inputLabel }}
-            setValue={setValue}
-          />
-        )
-      case 'Numbers12Digits':
-        return (
-          <InputTextAdapter
-            attrs={{ metadata: formData.metadata, name, inputLabel }}
+            attrs={{ metadata: formData.metadata, name, inputLabel, type }}
             setValue={setValue}
           />
         )

--- a/src/components/Placeholders/PaperDefinitionsPropTypes.js
+++ b/src/components/Placeholders/PaperDefinitionsPropTypes.js
@@ -17,9 +17,8 @@ const paperDefinitionsStepProptypes = PropTypes.shape({
 export const paperDefinitionsProptypes = PropTypes.shape({
   label: PropTypes.string.isRequired,
   icon: PropTypes.string,
-  featuredPlaceholder: PropTypes.bool.isRequired,
   placeholderIndex: PropTypes.number,
-  steps: PropTypes.oneOfType([
+  acquisitionSteps: PropTypes.oneOfType([
     PropTypes.array,
     PropTypes.arrayOf(paperDefinitionsStepProptypes).isRequired
   ]),

--- a/src/components/Placeholders/Placeholder.jsx
+++ b/src/components/Placeholders/Placeholder.jsx
@@ -167,7 +167,7 @@ const Placeholder = ({ placeholder, divider }) => {
           <ImportDropdown
             label={placeholder.label}
             icon={placeholder.icon}
-            hasSteps={placeholder?.steps.length > 0}
+            hasSteps={placeholder?.acquisitionSteps.length > 0}
           />
         </ActionMenu>
       )}

--- a/src/constants/papersDefinitions.json
+++ b/src/constants/papersDefinitions.json
@@ -69,31 +69,39 @@
         {
           "stepIndex": 1,
           "model": "scan",
+          "multipage": true,
           "illustration": "IlluGenericNewPage.svg",
           "text": "PaperJSON.generic.multiPages.text"
-        },
-        {
-          "pageIndex": 2,
-          "model": "information",
-          "illustration": "IlluGenericDate.svg",
-          "text": "PaperJSON.generic.date.text",
-          "attributes": [
-            {
-              "name": "date",
-              "type": "date",
-              "inputLabel": "PaperJSON.generic.date.inputLabel"
-            }
-          ]
         }
       ]
     },
     {
-      "label": "birth_certificate",
+      "label": "health_certificate",
       "placeholderIndex": 7,
       "icon": "heart",
       "featureDate": "issueDate",
       "maxDisplay": 4,
-      "steps": []
+      "acquisitionSteps": [
+        {
+          "stepIndex": 1,
+          "model": "scan",
+          "illustration": "illuGenericNewPage.svg",
+          "text": "PaperJSON.generic.singlePages.text"
+        },
+        {
+          "stepIndex": 2,
+          "model": "information",
+          "illustration": "illuGenericDate.svg",
+          "text": "PaperJSON.generic.date.text",
+          "attributes": [
+            {
+              "name": "issueDate",
+              "type": "date",
+              "inputLabel": "PaperJSON.generic.issueDate.inputLabel"
+            }
+          ]
+        }
+      ]
     },
     {
       "label": "health_insurance_card",
@@ -101,6 +109,13 @@
       "icon": "heart",
       "featureDate": "expirationDate",
       "maxDisplay": 2,
+      "acquisitionSteps": []
+    },
+    {
+      "label": "id_photo",
+      "icon": "people",
+      "featureDate": "Date",
+      "maxDisplay": 1,
       "acquisitionSteps": []
     },
     {
@@ -173,7 +188,28 @@
       "icon": "bill",
       "featureDate": "referenceDate",
       "maxDisplay": 3,
-      "acquisitionSteps": []
+      "acquisitionSteps": [
+        {
+          "stepIndex": 1,
+          "model": "scan",
+          "multipage": true,
+          "illustration": "illuGenericNewPage.svg",
+          "text": "PaperJSON.generic.multiPages.text"
+        },
+        {
+          "stepIndex": 2,
+          "model": "information",
+          "illustration": "illuGenericDate.svg",
+          "text": "PaperJSON.generic.date.text",
+          "attributes": [
+            {
+              "name": "referenceDate",
+              "type": "date",
+              "inputLabel": "PaperJSON.generic.periodeDate.inputLabel"
+            }
+          ]
+        }
+      ]
     },
     {
       "label": "tax_notice",
@@ -181,7 +217,28 @@
       "icon": "bank",
       "featureDate": "referenceYear",
       "maxDisplay": 3,
-      "acquisitionSteps": []
+      "acquisitionSteps": [
+        {
+          "stepIndex": 1,
+          "model": "scan",
+          "multipage": true,
+          "illustration": "illuGenericNewPage.svg",
+          "text": "PaperJSON.generic.multiPages.text"
+        },
+        {
+          "stepIndex": 2,
+          "model": "information",
+          "illustration": "illuGenericDate.svg",
+          "text": "PaperJSON.generic.date.text",
+          "attributes": [
+            {
+              "name": "referenceYear",
+              "type": "date",
+              "inputLabel": "PaperJSON.generic.periodeDate.inputLabel"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/constants/papersDefinitions.json
+++ b/src/constants/papersDefinitions.json
@@ -2,12 +2,11 @@
   "papersDefinitions": [
     {
       "label": "driver_license",
-      "featuredPlaceholder": true,
       "placeholderIndex": 2,
       "icon": "car",
       "featureDate": "carObtentionDate",
       "maxDisplay": 2,
-      "steps": [
+      "acquisitionSteps": [
         {
           "stepIndex": 1,
           "model": "scan",
@@ -30,7 +29,7 @@
           "attributes": [
             {
               "name": "number",
-              "type": "Numbers12Digits",
+              "type": "Number:12",
               "inputLabel": "PaperJSON.driverLicense.number.inputLabel"
             }
           ]
@@ -57,19 +56,16 @@
     },
     {
       "label": "energy_invoice",
-      "featuredPlaceholder": false,
       "icon": "bill",
       "featureDate": "issueDate",
       "maxDisplay": 4,
-      "steps": []
+      "acquisitionSteps": []
     },
     {
       "label": "family_record_book",
-      "featuredPlaceholder": false,
       "icon": "people",
-      "featureDate": "LastUpdate",
       "maxDisplay": 3,
-      "steps": [
+      "acquisitionSteps": [
         {
           "stepIndex": 1,
           "model": "scan",
@@ -93,7 +89,6 @@
     },
     {
       "label": "birth_certificate",
-      "featuredPlaceholder": false,
       "placeholderIndex": 7,
       "icon": "heart",
       "featureDate": "issueDate",
@@ -102,39 +97,35 @@
     },
     {
       "label": "health_insurance_card",
-      "featuredPlaceholder": true,
       "placeholderIndex": 4,
       "icon": "heart",
       "featureDate": "expirationDate",
       "maxDisplay": 2,
-      "steps": []
+      "acquisitionSteps": []
     },
     {
       "label": "isp_invoice",
-      "featuredPlaceholder": true,
       "placeholderIndex": 5,
       "icon": "bill",
       "featureDate": "issueDate",
       "maxDisplay": 6,
-      "steps": []
+      "acquisitionSteps": []
     },
     {
       "label": "national_insurance_card",
-      "featuredPlaceholder": true,
       "placeholderIndex": 3,
       "icon": "heart",
       "featureDate": "carObtentionDate",
       "maxDisplay": 2,
-      "steps": []
+      "acquisitionSteps": []
     },
     {
       "label": "national_id_card",
-      "featuredPlaceholder": true,
       "placeholderIndex": 1,
       "icon": "people",
       "featureDate": "expirationDate",
       "maxDisplay": 2,
-      "steps": [
+      "acquisitionSteps": [
         {
           "stepIndex": 1,
           "model": "scan",
@@ -157,7 +148,7 @@
           "attributes": [
             {
               "name": "number",
-              "type": "frenchIdCardNumber",
+              "type": "Number:12",
               "inputLabel": "PaperJSON.IDCard.number.inputLabel"
             }
           ]
@@ -179,20 +170,18 @@
     },
     {
       "label": "pay_sheet",
-      "featuredPlaceholder": false,
       "icon": "bill",
       "featureDate": "referenceDate",
       "maxDisplay": 3,
-      "steps": []
+      "acquisitionSteps": []
     },
     {
       "label": "tax_notice",
-      "featuredPlaceholder": true,
       "placeholderIndex": 6,
       "icon": "bank",
       "featureDate": "referenceYear",
       "maxDisplay": 3,
-      "steps": []
+      "acquisitionSteps": []
     }
   ]
 }

--- a/src/utils/getPlaceholders.js
+++ b/src/utils/getPlaceholders.js
@@ -8,7 +8,7 @@ import papersJSON from 'src/constants/papersDefinitions.json'
  * @property {string} type - Type of the attribute.
  */
 /**
- * @typedef {Object} Step
+ * @typedef {Object} AcquisitionSteps
  * @property {number} stepIndex - Position of the step.
  * @property {number} occurrence - Number of occurrence for this step.
  * @property {string} illustration - Name of the illustration.
@@ -19,9 +19,8 @@ import papersJSON from 'src/constants/papersDefinitions.json'
  * @typedef {Object} Paper
  * @property {string} label - Label of Paper.
  * @property {string} icon - Icon of Paper.
- * @property {boolean} featuredPlaceholder - Is visible on the Homepage.
  * @property {number} placeholderIndex - Position on the Placeholder list.
- * @property {Step[]} steps - Array of steps.
+ * @property {AcquisitionSteps[]} acquisitionSteps - Array of acquisition steps.
  * @property {string} featureDate - Reference the attribute "name" to be used as main date.
  * @property {number} maxDisplay - Number of document beyond which a "see more" button is displayed.
  */
@@ -29,7 +28,7 @@ import papersJSON from 'src/constants/papersDefinitions.json'
 /**
  * Filters and sorts the list of PlaceHolders
  * @param {Paper[]} papers Array of Papers
- * @returns an array of Papers filtered with the prop "featuredPlaceholder",
+ * @returns an array of Papers filtered with the prop "placeholderIndex",
  * which does not already exist in DB and
  * which sorted with the prop "placeholderIndex"
  */
@@ -40,6 +39,6 @@ export const getPlaceholders = (papers = []) =>
         !papers.some(
           paper =>
             get(paper, 'metadata.qualification.label') === paperDefinition.label
-        ) && paperDefinition.featuredPlaceholder
+        ) && paperDefinition.placeholderIndex
     )
     .sort((a, b) => a.placeholderIndex - b.placeholderIndex)

--- a/src/utils/getPlaceholders.spec.js
+++ b/src/utils/getPlaceholders.spec.js
@@ -14,11 +14,11 @@ describe('getPlaceholders', () => {
   it('should return correct list of placeholders whitout param', () => {
     const placeholders = getPlaceholders()
 
-    expect(placeholders).toHaveLength(6)
+    expect(placeholders).toHaveLength(7)
   })
   it('should return correct list of placeholders with param', () => {
     const placeholders = getPlaceholders(fakePapers)
 
-    expect(placeholders).toHaveLength(5)
+    expect(placeholders).toHaveLength(6)
   })
 })


### PR DESCRIPTION
PapersDefinition added:
- Added `multipage` prop in `acquisitionSteps`
- Replace `birth_certificate` to `health_certificate`
- Added `id_photo`
- Added steps of `pay_sheet`
- Added steps of `tax_notice`

Refactoring:
- Renamed `steps` to `acquisitionSteps`
- Renamed `Numbers12Digits` & `frenchIdCardNumber` value to `Number:12`
- Removed `featuredPlaceholder` which has become useless

