### PR TITLE
feat: Improve InputTextAdapter

### DIFF
--- a/src/components/ModelSteps/widgets/InputTextAdapter.jsx
+++ b/src/components/ModelSteps/widgets/InputTextAdapter.jsx
@@ -1,10 +1,13 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useMemo, useCallback } from 'react'
+import PropTypes from 'prop-types'
 
 import TextField from 'cozy-ui/transpiled/react/MuiCozyTheme/TextField'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
+import { makeInputTypeAndLength } from 'src/utils/makeInputTypeAndLength'
+
 const InputTextAdapter = ({ attrs, setValue }) => {
-  const { name, inputLabel, metadata } = attrs
+  const { name, inputLabel, metadata, type } = attrs
   const { t } = useI18n()
   const [value, setState] = useState(metadata[name] || '')
 
@@ -12,16 +15,46 @@ const InputTextAdapter = ({ attrs, setValue }) => {
     setValue(prev => ({ ...prev, [name]: value }))
   }, [name, value, setValue])
 
+  const { inputType, inputMaxLength } = useMemo(
+    () => makeInputTypeAndLength(type),
+    [type]
+  )
+
+  const handleOnChange = useCallback(
+    evt => {
+      const { value } = evt.target
+      if (inputMaxLength > 0 && value.length <= inputMaxLength) {
+        setState(value)
+      } else if (inputMaxLength === 0) {
+        setState(value)
+      }
+    },
+    [inputMaxLength]
+  )
+
   return (
     <TextField
       value={value}
-      onChange={evt => setState(evt.target.value)}
+      type={inputType}
+      onChange={handleOnChange}
       variant={'outlined'}
       label={inputLabel ? t(inputLabel) : ''}
       fullWidth
       autoFocus
     />
   )
+}
+
+const attrsProptypes = PropTypes.shape({
+  name: PropTypes.string,
+  inputLabel: PropTypes.string,
+  metadata: PropTypes.shape({ ['attrsProptypes.name']: PropTypes.string }),
+  type: PropTypes.string
+})
+
+InputTextAdapter.propTypes = {
+  attrs: attrsProptypes.isRequired,
+  setValue: PropTypes.func.isRequired
 }
 
 export default InputTextAdapter

--- a/src/components/ModelSteps/widgets/InputTextAdapter.spec.jsx
+++ b/src/components/ModelSteps/widgets/InputTextAdapter.spec.jsx
@@ -1,0 +1,63 @@
+'use strict'
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+
+import AppLike from 'test/components/AppLike'
+import InputTextAdapter from 'src/components/ModelSteps/widgets/InputTextAdapter'
+
+jest.mock('cozy-scanner', () => ({
+  getBoundT: jest.fn(() => jest.fn())
+}))
+
+const mockAttrs = (type = '', value = 'fakeValue') => ({
+  name: 'name01',
+  inputLabel: 'PaperJSON.IDCard.number.inputLabel',
+  metadata: { name01: value },
+  type
+})
+
+const setup = (attrs = mockAttrs()) => {
+  const value = attrs.metadata.name01
+  const container = render(
+    <AppLike>
+      <InputTextAdapter attrs={attrs} setValue={jest.fn()} />
+    </AppLike>
+  )
+  const input = container.getByDisplayValue(value)
+
+  return {
+    input,
+    ...container
+  }
+}
+
+describe('InputTextAdapter components:', () => {
+  it('should be rendered correctly', () => {
+    const { container } = setup()
+
+    expect(container).toBeDefined()
+  })
+
+  it('should have a value of 5 letters', () => {
+    const { input } = setup(mockAttrs(':5'))
+    fireEvent.change(input, { target: { value: 'abcde' } })
+
+    expect(input.value).toBe('abcde')
+  })
+
+  it('should have a value of "fakeValue"', () => {
+    const { input } = setup(mockAttrs(':5'))
+    fireEvent.change(input, { target: { value: 'abcdefgh' } })
+    expect(input.value).toBe('fakeValue')
+
+    fireEvent.change(input, { target: { value: '123456789' } })
+    expect(input.value).toBe('fakeValue')
+  })
+
+  it('should have a value of 5 digits', () => {
+    const { input } = setup(mockAttrs('Number:5', '789'))
+    fireEvent.change(input, { target: { value: '12345' } })
+
+    expect(input.value).toBe('12345')
+  })
+})

--- a/src/utils/makeInputTypeAndLength.js
+++ b/src/utils/makeInputTypeAndLength.js
@@ -1,0 +1,37 @@
+import log from 'cozy-logger'
+const NUMBER = 'Number'
+const TEXT = 'Text'
+
+/**
+ * Make type and length properties
+ * @param {string} typeDefinition - Definition of type & length of the input
+ * @example
+ * // For make input number with contraint length to 12
+ * makeInputTypeAndLength("Number:12")
+ * // For make input text with no contraint length
+ * makeInputTypeAndLength("Text")
+ */
+export const makeInputTypeAndLength = typeDefinition => {
+  const [type = typeDefinition, maxLength] = typeDefinition.split(':')
+  const result = { inputType: '', inputMaxLength: 0 }
+
+  switch (type) {
+    case NUMBER:
+      result.inputType = NUMBER.toLowerCase()
+      break
+    case TEXT:
+      result.inputType = TEXT.toLowerCase()
+      break
+    default:
+      log(
+        'warn',
+        '"type" in "attributes" property is not defined or unexpected, "type" set to "text" by default'
+      )
+      result.inputType = TEXT.toLowerCase()
+      break
+  }
+
+  if (maxLength) result.inputMaxLength = parseInt(maxLength, 10)
+
+  return result
+}

--- a/src/utils/makeInputTypeAndLength.spec.js
+++ b/src/utils/makeInputTypeAndLength.spec.js
@@ -1,0 +1,45 @@
+import { makeInputTypeAndLength } from 'src/utils/makeInputTypeAndLength'
+
+describe('makeInputTypeAndLength', () => {
+  it('should return type "number" with length to 0', () => {
+    const response0 = makeInputTypeAndLength('Number')
+    const response1 = makeInputTypeAndLength('Number:')
+    const response2 = makeInputTypeAndLength('Number:0')
+
+    const expected = { inputType: 'number', inputMaxLength: 0 }
+
+    expect(response0).toEqual(expected)
+    expect(response1).toEqual(expected)
+    expect(response2).toEqual(expected)
+  })
+  it('should return type "number" with length to 10', () => {
+    const response = makeInputTypeAndLength('Number:10')
+
+    const expected = { inputType: 'number', inputMaxLength: 10 }
+
+    expect(response).toEqual(expected)
+  })
+
+  it('should return type "text" with length to 0', () => {
+    const response0 = makeInputTypeAndLength('')
+    const response1 = makeInputTypeAndLength('Other:')
+    const response2 = makeInputTypeAndLength('Text')
+
+    const expected = { inputType: 'text', inputMaxLength: 0 }
+
+    expect(response0).toEqual(expected)
+    expect(response1).toEqual(expected)
+    expect(response2).toEqual(expected)
+  })
+  it('should return type "text" with length to 10', () => {
+    const response0 = makeInputTypeAndLength('Text:10')
+    const response1 = makeInputTypeAndLength('String:10')
+    const response2 = makeInputTypeAndLength(':10')
+
+    const expected = { inputType: 'text', inputMaxLength: 10 }
+
+    expect(response0).toEqual(expected)
+    expect(response1).toEqual(expected)
+    expect(response2).toEqual(expected)
+  })
+})


### PR DESCRIPTION
Added function `makeInputTypeAndLength` to manage the property `type` & `maxLength` of the input depending on the value of the `type` property in the `attributes` properties of the current `acquisitionSteps
