### PR TITLE
feat: Change occurrence attribute to multipage

### DIFF
--- a/src/components/ModelSteps/AcquisitionResult.jsx
+++ b/src/components/ModelSteps/AcquisitionResult.jsx
@@ -1,18 +1,21 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import Card from 'cozy-ui/transpiled/react/Card'
 import DialogActions from 'cozy-ui/transpiled/react/DialogActions'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import Avatar from 'cozy-ui/transpiled/react/Avatar'
-import Button from 'cozy-ui/transpiled/react/Button'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import Check from 'cozy-ui/transpiled/react/Icons/Check'
-import FileTypePdfIcon from 'cozy-ui/transpiled/react/Icons/FileTypePdf'
+import Button, { ButtonLink } from 'cozy-ui/transpiled/react/Button'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import FileTypePdfIcon from 'cozy-ui/transpiled/react/Icons/FileTypePdf'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import Check from 'cozy-ui/transpiled/react/Icons/Check'
+import Camera from 'cozy-ui/transpiled/react/Icons/Camera'
 
 import { useStepperDialogContext } from 'src/components/Hooks/useStepperDialogContext'
 import { useFormDataContext } from 'src/components/Hooks/useFormDataContext'
+import { paperDefinitionsStepProptypes } from 'src/constants/PaperDefinitionsPropTypes'
 
 const isPDF = file => file.type === 'application/pdf'
 
@@ -21,8 +24,9 @@ const AcquisitionResult = ({ file, setFile, currentStep }) => {
   const { isMobile } = useBreakpoints()
   const { nextStep } = useStepperDialogContext()
   const { setFormData } = useFormDataContext()
+  const { page, multipage } = currentStep
 
-  const onValid = () => {
+  const onValid = (repeat = false) => {
     setFormData(prev => ({
       ...prev,
       data: [
@@ -30,12 +34,13 @@ const AcquisitionResult = ({ file, setFile, currentStep }) => {
         {
           file,
           fileMetadata: {
-            page: currentStep.page
+            page: !multipage ? page : undefined
           }
         }
       ]
     }))
-    nextStep()
+    if (!repeat) nextStep()
+    else setFile(null)
   }
 
   return (
@@ -77,16 +82,32 @@ const AcquisitionResult = ({ file, setFile, currentStep }) => {
           />
         </Card>
       </div>
-      <DialogActions disableSpacing className={'columnLayout'}>
+      <DialogActions disableSpacing className={'columnLayout u-mh-0'}>
         <Button
           className="u-db"
           extension="full"
           label={t('common.next')}
-          onClick={onValid}
+          onClick={() => onValid(false)}
         />
+        {multipage && (
+          <ButtonLink
+            className={'u-ml-0 u-mb-half'}
+            extension="full"
+            theme={'secondary'}
+            icon={Camera}
+            label={t('Acquisition.repeat')}
+            onClick={() => onValid(true)}
+          />
+        )}
       </DialogActions>
     </>
   )
+}
+
+AcquisitionResult.propTypes = {
+  file: PropTypes.object.isRequired,
+  setFile: PropTypes.func.isRequired,
+  currentStep: paperDefinitionsStepProptypes
 }
 
 export default AcquisitionResult

--- a/src/components/ModelSteps/AcquisitionResult.jsx
+++ b/src/components/ModelSteps/AcquisitionResult.jsx
@@ -15,7 +15,7 @@ import Camera from 'cozy-ui/transpiled/react/Icons/Camera'
 
 import { useStepperDialogContext } from 'src/components/Hooks/useStepperDialogContext'
 import { useFormDataContext } from 'src/components/Hooks/useFormDataContext'
-import { paperDefinitionsStepProptypes } from 'src/constants/PaperDefinitionsPropTypes'
+import { PaperDefinitionsStepPropTypes } from 'src/constants/PaperDefinitionsPropTypes'
 
 const isPDF = file => file.type === 'application/pdf'
 
@@ -107,7 +107,7 @@ const AcquisitionResult = ({ file, setFile, currentStep }) => {
 AcquisitionResult.propTypes = {
   file: PropTypes.object.isRequired,
   setFile: PropTypes.func.isRequired,
-  currentStep: paperDefinitionsStepProptypes
+  currentStep: PaperDefinitionsStepPropTypes
 }
 
 export default AcquisitionResult

--- a/src/components/Placeholders/Placeholder.jsx
+++ b/src/components/Placeholders/Placeholder.jsx
@@ -17,7 +17,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import ImportDropdown from 'src/components/ImportDropdown/ImportDropdown'
 import { useStepperDialogContext } from 'src/components/Hooks/useStepperDialogContext'
-import { paperDefinitionsProptypes } from 'src/constants/PaperDefinitionsPropTypes'
+import { PaperDefinitionsPropTypes } from 'src/constants/PaperDefinitionsPropTypes'
 import { useScannerI18n } from 'src/components/Hooks/useScannerI18n'
 import papersJSON from 'src/constants/papersDefinitions.json'
 
@@ -181,7 +181,7 @@ const Placeholder = ({ placeholder, divider }) => {
 }
 
 Placeholder.propTypes = {
-  placeholder: paperDefinitionsProptypes.isRequired,
+  placeholder: PaperDefinitionsPropTypes.isRequired,
   divider: PropTypes.bool
 }
 

--- a/src/components/Placeholders/Placeholder.jsx
+++ b/src/components/Placeholders/Placeholder.jsx
@@ -17,7 +17,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import ImportDropdown from 'src/components/ImportDropdown/ImportDropdown'
 import { useStepperDialogContext } from 'src/components/Hooks/useStepperDialogContext'
-import { paperDefinitionsProptypes } from 'src/components/Placeholders/PaperDefinitionsPropTypes'
+import { paperDefinitionsProptypes } from 'src/constants/PaperDefinitionsPropTypes'
 import { useScannerI18n } from 'src/components/Hooks/useScannerI18n'
 import papersJSON from 'src/constants/papersDefinitions.json'
 

--- a/src/constants/PaperDefinitionsPropTypes.js
+++ b/src/constants/PaperDefinitionsPropTypes.js
@@ -5,10 +5,11 @@ const paperDefinitionsStepAttrProptypes = PropTypes.shape({
   type: PropTypes.string.isRequired
 })
 
-const paperDefinitionsStepProptypes = PropTypes.shape({
+export const paperDefinitionsStepProptypes = PropTypes.shape({
   stepIndex: PropTypes.number.isRequired,
-  occurrence: PropTypes.number,
   model: PropTypes.string.isRequired,
+  multipage: PropTypes.bool,
+  page: PropTypes.string,
   illustration: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
   attributes: PropTypes.arrayOf(paperDefinitionsStepAttrProptypes)

--- a/src/constants/PaperDefinitionsPropTypes.js
+++ b/src/constants/PaperDefinitionsPropTypes.js
@@ -1,27 +1,27 @@
 import PropTypes from 'prop-types'
 
-const paperDefinitionsStepAttrProptypes = PropTypes.shape({
+const PaperDefinitionsStepAttrPropTypes = PropTypes.shape({
   name: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired
 })
 
-export const paperDefinitionsStepProptypes = PropTypes.shape({
+export const PaperDefinitionsStepPropTypes = PropTypes.shape({
   stepIndex: PropTypes.number.isRequired,
   model: PropTypes.string.isRequired,
   multipage: PropTypes.bool,
   page: PropTypes.string,
   illustration: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
-  attributes: PropTypes.arrayOf(paperDefinitionsStepAttrProptypes)
+  attributes: PropTypes.arrayOf(PaperDefinitionsStepAttrPropTypes)
 })
 
-export const paperDefinitionsProptypes = PropTypes.shape({
+export const PaperDefinitionsPropTypes = PropTypes.shape({
   label: PropTypes.string.isRequired,
   icon: PropTypes.string,
   placeholderIndex: PropTypes.number,
   acquisitionSteps: PropTypes.oneOfType([
     PropTypes.array,
-    PropTypes.arrayOf(paperDefinitionsStepProptypes).isRequired
+    PropTypes.arrayOf(PaperDefinitionsStepPropTypes).isRequired
   ]),
   featureDate: PropTypes.string,
   maxDisplay: PropTypes.number.isRequired

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,5 +1,6 @@
 {
   "Acquisition": {
+    "repeat": "Scan an additional page",
     "retry": "Take over",
     "success": "Acquisition success"
   },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1,5 +1,6 @@
 {
   "Acquisition": {
+    "repeat": "Scanner une page supplémentaire",
     "retry": "Reprendre la photo",
     "success": "Acquisition réussie"
   },


### PR DESCRIPTION
Change `occurrence` attribute to `multipage` in `acquisitionSteps`

The `occurence` attribute was never built into the code, it should have done what `multipage` does now.
A Paper does not necessarily have a defined number of pages, this attribute allows the user to load as many files as needed.