### PR TITLE
fix: Added cozy-sharings permission

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -34,6 +34,11 @@
       "type": "io.cozy.files",
       "verbs": ["ALL"]
     },
+    "sharings": {
+      "description": "Required to have access to the sharings in realtime",
+      "type": "io.cozy.sharings",
+      "verbs": ["ALL"]
+    },
     "settings": {
       "description": "Required by the cozy-bar to display Claudy and know which applications are coming soon",
       "type": "io.cozy.settings",


### PR DESCRIPTION
`cozy-sharings` permission is needed for used `Viewer`