### PR TITLE
feat: Remove sharing button

### DIFF
--- a/src/components/Viewer/Footer/BottomSheetContent.jsx
+++ b/src/components/Viewer/Footer/BottomSheetContent.jsx
@@ -7,7 +7,6 @@ import Paper from 'cozy-ui/transpiled/react/Paper'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import Stack from 'cozy-ui/transpiled/react/Stack'
 
-import Sharing from './Sharing'
 import getPanelBlocks, { panelBlocksSpecs } from '../Panel/getPanelBlocks'
 
 const useStyles = makeStyles(theme => ({
@@ -26,7 +25,6 @@ const BottomSheetContent = forwardRef(({ file, FileActionButton }, ref) => {
       className={cx('u-flex u-flex-column u-ov-hidden', styles.stack)}
     >
       <Paper className={'u-flex u-ph-1 u-pb-1'} elevation={2} square ref={ref}>
-        <Sharing file={file} />
         <FileActionButton file={file} />
       </Paper>
       {panelBlocks.map((PanelBlock, index) => (

--- a/src/components/Viewer/Footer/FooterContent.jsx
+++ b/src/components/Viewer/Footer/FooterContent.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import { makeStyles } from '@material-ui/core/styles'
 
 import { showPanel } from '../helpers'
-import Sharing from './Sharing'
 import ForwardWebButton from './ForwardWebButton'
 import DownloadButton from './DownloadButton'
 import BottomSheetWrapper from './BottomSheetWrapper'
@@ -44,7 +43,6 @@ const FooterContent = ({ file, toolbarRef }) => {
 
   return (
     <div className={styles.footer}>
-      <Sharing file={file} />
       <FileActionButton file={file} />
     </div>
   )


### PR DESCRIPTION
The cozy share button next to the transfer button causes too much misunderstanding, until a better placement or renaming, we will remove it