### PR TITLE
fix: Contrains & position of inputs in steps

### DIFF
--- a/src/components/ModelSteps/Information.jsx
+++ b/src/components/ModelSteps/Information.jsx
@@ -18,7 +18,7 @@ const Information = ({ currentStep }) => {
   const { formData, setFormData } = useFormData()
   const { nextStep } = useStepperDialog()
   const [value, setValue] = useState({})
-  const [validInput, setValidInput] = useState(false)
+  const [validInput, setValidInput] = useState({})
 
   const submit = () => {
     if (value) {
@@ -38,21 +38,32 @@ const Information = ({ currentStep }) => {
       attributes.map(({ name, type, inputLabel }) => {
         switch (type) {
           case 'date':
-            return (
-              <InputDateAdapter
-                attrs={{ metadata: formData.metadata, name, inputLabel }}
-                setValue={setValue}
-                setValidInput={setValidInput}
-              />
-            )
+            return function InputDate(props) {
+              return (
+                <InputDateAdapter
+                  attrs={{ metadata: formData.metadata, name, inputLabel }}
+                  setValue={setValue}
+                  setValidInput={setValidInput}
+                  {...props}
+                />
+              )
+            }
           default:
-            return (
-              <InputTextAdapter
-                attrs={{ metadata: formData.metadata, name, inputLabel, type }}
-                setValue={setValue}
-                setValidInput={setValidInput}
-              />
-            )
+            return function InputText(props) {
+              return (
+                <InputTextAdapter
+                  attrs={{
+                    metadata: formData.metadata,
+                    name,
+                    inputLabel,
+                    type
+                  }}
+                  setValue={setValue}
+                  setValidInput={setValidInput}
+                  {...props}
+                />
+              )
+            }
         }
       }),
     [attributes, formData.metadata]
@@ -61,6 +72,11 @@ const Information = ({ currentStep }) => {
   const hasMarginBottom = useCallback(idx => hasNextvalue(idx, inputs), [
     inputs
   ])
+
+  const allInputsValid = useMemo(
+    () => Object.keys(validInput).every(val => validInput[val]),
+    [validInput]
+  )
 
   return (
     <>
@@ -71,8 +87,11 @@ const Information = ({ currentStep }) => {
           iconSize={'medium'}
           title={t(text)}
           text={inputs.map((Input, idx) => (
-            <div key={idx} className={hasMarginBottom(idx) ? 'u-mb-1' : ''}>
-              {Input}
+            <div
+              key={idx}
+              className={hasMarginBottom(idx) ? 'u-mb-3 u-pb-1' : ''}
+            >
+              <Input idx={idx} />
             </div>
           ))}
         />
@@ -83,7 +102,7 @@ const Information = ({ currentStep }) => {
           extension="full"
           label={t('common.next')}
           onClick={submit}
-          disabled={!validInput}
+          disabled={!allInputsValid}
         />
       </DialogActions>
     </>

--- a/src/components/ModelSteps/widgets/InputDateAdapter.jsx
+++ b/src/components/ModelSteps/widgets/InputDateAdapter.jsx
@@ -22,11 +22,12 @@ const useStyles = makeStyles(() => ({
   }
 }))
 
-const InputDateAdapter = ({ attrs, setValue, setValidInput }) => {
+const InputDateAdapter = ({ attrs, setValue, setValidInput, idx }) => {
   const { name, inputLabel, metadata } = attrs
   const { t, lang } = useI18n()
   const classes = useStyles()
   const [locales, setLocales] = useState('')
+  const [isError, setIsError] = useState(false)
   const [selectedDate, handleDateChange] = useState(metadata[name] || null)
 
   useEffect(() => {
@@ -45,6 +46,13 @@ const InputDateAdapter = ({ attrs, setValue, setValidInput }) => {
     selectedDate && setValue(prev => ({ ...prev, [name]: selectedDate }))
   }, [name, selectedDate, setValue])
 
+  useEffect(() => {
+    setValidInput(prev => ({
+      ...prev,
+      [idx]: isError
+    }))
+  }, [idx, isError, setValidInput])
+
   return (
     <MuiPickersUtilsProvider
       utils={DateFnsUtils}
@@ -62,7 +70,7 @@ const InputDateAdapter = ({ attrs, setValue, setValidInput }) => {
         cancelLabel={t('common.cancel')}
         format={lang === 'fr' ? 'dd/MM/yyyy' : 'MM/dd/yyyy'}
         onError={(err, val) => {
-          setValidInput(val === null || !!new Date(val).getTime())
+          setIsError(val === null || !!new Date(val).getTime())
         }}
       />
     </MuiPickersUtilsProvider>

--- a/src/components/ModelSteps/widgets/InputTextAdapter.jsx
+++ b/src/components/ModelSteps/widgets/InputTextAdapter.jsx
@@ -6,15 +6,18 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import { makeInputTypeAndLength } from 'src/utils/makeInputTypeAndLength'
 
-const InputTextAdapter = ({ attrs, setValue, setValidInput }) => {
+const InputTextAdapter = ({ attrs, setValue, setValidInput, idx }) => {
   const { name, inputLabel, metadata, type } = attrs
   const { t } = useI18n()
   const [value, setState] = useState(metadata[name] || '')
 
   useEffect(() => {
-    setValidInput(value.length === 0 || value.length === inputMaxLength)
+    setValidInput(prev => ({
+      ...prev,
+      [idx]: value.length === 0 || value.length === inputMaxLength
+    }))
     setValue(prev => ({ ...prev, [name]: value }))
-  }, [name, value, setValue, setValidInput, inputMaxLength])
+  }, [name, value, setValue, setValidInput, inputMaxLength, idx])
 
   const { inputType, inputMaxLength } = useMemo(
     () => makeInputTypeAndLength(type),


### PR DESCRIPTION
Instead of returning the Inputs components directly, we wrap them in a function so that we can add props to them.
This allows us to simply control, in case there are several Inputs, that they all meet the conditions to continue.