### PR TITLE
feat: Limit image size in pdf

### DIFF
--- a/src/components/Contexts/FormDataProvider.jsx
+++ b/src/components/Contexts/FormDataProvider.jsx
@@ -37,13 +37,27 @@ const loadPdfFromFile = async file => {
   })
 }
 
+const getImageScaleRatio = ({ pdfImg }) => {
+  const maxSizeInPixel = 900
+  const longerSideSizeInPixel = Math.max(pdfImg.height, pdfImg.width)
+
+  let scaleRatio = 1
+
+  if (maxSizeInPixel < longerSideSizeInPixel) {
+    scaleRatio = maxSizeInPixel / longerSideSizeInPixel
+  }
+
+  return scaleRatio
+}
+
 const addImageToPdf = async ({ pdf, fileToAdd }) => {
   const fileB64 = await fileToBase64(fileToAdd)
   let img
   if (fileToAdd.type === 'image/png') img = await pdf.embedPng(fileB64)
   if (fileToAdd.type === 'image/jpeg') img = await pdf.embedJpg(fileB64)
-  const imgScaled = img.scale(0.5)
-  const page = pdf.addPage()
+  const scaleRatio = getImageScaleRatio({ pdfImg: img })
+  const imgScaled = img.scale(scaleRatio)
+  const page = pdf.addPage([imgScaled.width, imgScaled.height])
   const { width: pageWidth, height: pageHeight } = page.getSize()
   page.drawImage(img, {
     x: pageWidth / 2 - imgScaled.width / 2,


### PR DESCRIPTION
As the form allows user to import any image we want to limit the image
dimensions in the generated PDF

The image is resized regarding its longest side

Current size limitation is `900px` wide. This is a randomly chosen number, so let's discuss about which dimension we want as a max image size.