### PR TITLE
Feat/resize images before added to pdf

### DIFF
--- a/src/components/Contexts/FormDataProvider.jsx
+++ b/src/components/Contexts/FormDataProvider.jsx
@@ -19,12 +19,12 @@ const {
 
 const FormDataContext = createContext()
 
-const fileToBase64 = async audioFile => {
+const fileToBase64 = async file => {
   return new Promise((resolve, reject) => {
     let reader = new FileReader()
     reader.onerror = reject
     reader.onload = e => resolve(e.target.result)
-    reader.readAsDataURL(audioFile)
+    reader.readAsDataURL(file)
   })
 }
 


### PR DESCRIPTION
`img.scale()` method only resize the image visually but keep the
original image binary

This may produce a document that is bigger than needed

We chose to resize the image dimensions before adding it to the PDF
document so only necessary pixel are stored and resulting document is
lighter