### PR TITLE
Fix/forward translation

### DIFF
--- a/src/components/Actions/utils.js
+++ b/src/components/Actions/utils.js
@@ -32,8 +32,8 @@ export const forwardFile = async (client, file, t) => {
   try {
     const url = await getSharingLink(client, file, true)
     const shareData = {
-      title: t('viewer.shareData.title', { name: file.name }),
-      text: t('viewer.shareData.text', { name: file.name }),
+      title: t('viewer.shareData.title', { name: file[0].name }),
+      text: t('viewer.shareData.text', { name: file[0].name }),
       url
     }
     navigator.share(shareData)

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -178,5 +178,12 @@
   "Scan": {
     "useExistingPic": "I already have a picture",
     "takePic": "Take a picture"
+  },
+  "viewer": {
+    "shareData": {
+      "title": "Link to my document %{name}",
+      "text": "Link to my document %{name}: ",
+      "error": "Problem with link recovery: %{error}"
+    }
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,7 +4,7 @@
     "retry": "Take over",
     "success": "Acquisition success"
   },
-  "actions": {
+  "action": {
     "download": "Download",
     "moveTo": "Move to…",
     "forward": "Forward",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -184,5 +184,12 @@
   "Scan": {
     "takePic": "Prendre en photo",
     "useExistingPic": "J'ai déjà une photo"
+  },
+  "viewer": {
+    "shareData": {
+      "title": "Lien vers mon document %{name}",
+      "text": "Voici un lien vers mon document %{name} : ",
+      "error": "Problème avec la récupération du lien : %{error}"
+    }
   }
 }


### PR DESCRIPTION
⚠️ `viewer.shareData` already exist in `src/components/Viewer/locales/` translations. We should refactor this functionality later in order to have one single translation