### PR TITLE
Feat/onboarding

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -15,6 +15,7 @@ import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import HomeWrapper from 'src/components/HomeWrapper/HomeWrapper'
 import PapersList from 'src/components/Papers/PapersList'
 import FileViewerWithQuery from 'src/components/Viewer/FileViewerWithQuery'
+import Onboarding from 'src/components/Onboarding/Onboarding'
 import { ModalStack } from 'src/components/Contexts/ModalProvider'
 import { useStepperDialog } from 'src/components/Hooks/useStepperDialog'
 import StepperDialogWrapper from 'src/components/StepperDialogWrapper/StepperDialogWrapper'
@@ -55,6 +56,7 @@ export const App = () => {
                   path="/file/:fileId"
                   component={FileViewerWithQuery}
                 />
+                <Route exact path="/onboarding" component={Onboarding} />
                 <Redirect from="*" to="/" />
               </Switch>
 

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -11,31 +11,20 @@ import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
-import Fab from 'cozy-ui/transpiled/react/Fab'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import PlusIcon from 'cozy-ui/transpiled/react/Icons/Plus'
 
 import HomeWrapper from 'src/components/HomeWrapper/HomeWrapper'
 import PapersList from 'src/components/Papers/PapersList'
 import FileViewerWithQuery from 'src/components/Viewer/FileViewerWithQuery'
 import { ModalStack } from 'src/components/Contexts/ModalProvider'
-import PlaceholderThemesList from 'src/components/Placeholders/PlaceholderThemesList'
-import { usePlaceholderModal } from 'src/components/Hooks/usePlaceholderModal'
 import { useStepperDialog } from 'src/components/Hooks/useStepperDialog'
 import StepperDialogWrapper from 'src/components/StepperDialogWrapper/StepperDialogWrapper'
 import { FormDataProvider } from 'src/components/Contexts/FormDataProvider'
-
-const styleFab = { position: 'fixed', zIndex: 10 }
 
 export const App = () => {
   const client = useClient()
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const { BarCenter } = cozy.bar
-  const {
-    showPlaceholderThemesList,
-    setShowPlaceholderThemesList
-  } = usePlaceholderModal()
 
   const { isStepperDialogOpen } = useStepperDialog()
 
@@ -69,21 +58,6 @@ export const App = () => {
                 <Redirect from="*" to="/" />
               </Switch>
 
-              <Fab
-                color="primary"
-                aria-label={t('Home.Fab.ariaLabel')}
-                style={styleFab}
-                className="u-bottom-m u-right-m"
-                onClick={() => setShowPlaceholderThemesList(true)}
-              >
-                <Icon icon={PlusIcon} />
-              </Fab>
-              {showPlaceholderThemesList && (
-                <PlaceholderThemesList
-                  title={t('PlaceholdersList.title', { name: '' })}
-                  onClose={() => setShowPlaceholderThemesList(false)}
-                />
-              )}
               {isStepperDialogOpen && (
                 <FormDataProvider>
                   <StepperDialogWrapper />

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -5,6 +5,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Empty from 'cozy-ui/transpiled/react/Empty'
 
 import PaperGroup from 'src/components/Papers/PaperGroup'
+import { PapersFab } from 'src/components/PapersFab/PapersFab'
 import FeaturedPlaceholdersList from 'src/components/Placeholders/FeaturedPlaceholdersList'
 import HomeCloud from 'src/assets/icons/HomeCloud.svg'
 
@@ -26,6 +27,7 @@ const Home = ({ hasPapers }) => {
         <PaperGroup />
       )}
       <FeaturedPlaceholdersList />
+      <PapersFab />
     </>
   )
 }

--- a/src/components/Onboarding/Onboarding.jsx
+++ b/src/components/Onboarding/Onboarding.jsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { useHistory } from 'react-router-dom'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+import Button from 'cozy-ui/transpiled/react/Button'
+import Empty from 'cozy-ui/transpiled/react/Empty'
+import HomeCloud from 'src/assets/icons/HomeCloud.svg'
+
+const Onboarding = () => {
+  const history = useHistory()
+  const { t } = useI18n()
+
+  const onClick = () => {
+    history.push({
+      pathname: `/`
+    })
+  }
+
+  return (
+    <div
+      className={
+        'u-pos-fixed u-top-0 u-left-0 u-bottom-0 u-right-0 u-m-1 u-flex u-flex-column'
+      }
+    >
+      <Empty
+        icon={HomeCloud}
+        iconSize={'large'}
+        title={t('Home.Empty.title')}
+        text={t('Home.Empty.text')}
+        layout={false}
+        className={'u-ph-1 u-flex-grow-1'}
+      />
+      <Button
+        theme="primary"
+        onClick={onClick}
+        label={t('Onboarding.cta')}
+        className={'u-flex-grow-0'}
+      />
+    </div>
+  )
+}
+
+export default Onboarding

--- a/src/components/Papers/PapersList.jsx
+++ b/src/components/Papers/PapersList.jsx
@@ -16,6 +16,7 @@ import { fetchCurrentUser } from 'src/helpers/fetchCurrentUser'
 import { getPapersByLabel } from 'src/helpers/queries'
 import { useScannerI18n } from 'src/components/Hooks/useScannerI18n'
 import PaperLine from 'src/components/Papers/PaperLine'
+import { PapersFab } from 'src/components/PapersFab/PapersFab'
 import makeActions from 'src/components/Actions/makeActions'
 import { useModal } from 'src/components/Hooks/useModal'
 import {
@@ -117,6 +118,7 @@ const PapersList = ({ history, match }) => {
           ))}
         </div>
       </List>
+      <PapersFab />
     </>
   )
 }

--- a/src/components/PapersFab/PapersFab.jsx
+++ b/src/components/PapersFab/PapersFab.jsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Fab from 'cozy-ui/transpiled/react/Fab'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import PlusIcon from 'cozy-ui/transpiled/react/Icons/Plus'
+
+import PlaceholderThemesList from 'src/components/Placeholders/PlaceholderThemesList'
+import { usePlaceholderModal } from 'src/components/Hooks/usePlaceholderModal'
+
+const styleFab = { position: 'fixed', zIndex: 10 }
+
+export const PapersFab = () => {
+  const { t } = useI18n()
+
+  const {
+    showPlaceholderThemesList,
+    setShowPlaceholderThemesList
+  } = usePlaceholderModal()
+
+  return (
+    <>
+      <Fab
+        color="primary"
+        aria-label={t('Home.Fab.ariaLabel')}
+        style={styleFab}
+        className="u-bottom-m u-right-m"
+        onClick={() => setShowPlaceholderThemesList(true)}
+      >
+        <Icon icon={PlusIcon} />
+      </Fab>
+      {showPlaceholderThemesList && (
+        <PlaceholderThemesList
+          title={t('PlaceholdersList.title', { name: '' })}
+          onClose={() => setShowPlaceholderThemesList(false)}
+        />
+      )}
+    </>
+  )
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -88,6 +88,9 @@
   "items": {
     "other": "Others…"
   },
+  "Onboarding": {
+    "cta": "Let's go!"
+  },
   "PaperJSON": {
     "generic": {
       "front": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -88,6 +88,9 @@
   "items": {
     "other": "Autres…"
   },
+  "Onboarding": {
+    "cta": "C'est parti !"
+  },
   "PaperJSON": {
     "generic": {
       "cover": {


### PR DESCRIPTION
This adds a `/onboarding` route that explains how to use the app

This new view should not display the Fab menu, so Fab menu has been moved into a dedicated component that is used in related component instead of into the App top level.

![image](https://user-images.githubusercontent.com/1884255/140776006-2e9dd18d-76cf-468b-a555-c465a13e0e7b.png)
![image](https://user-images.githubusercontent.com/1884255/140776177-24d56370-cab3-4d0e-92df-2ccb608b8106.png)
