### PR TITLE
fix: Filename is displayed instead of the pageName

### DIFF
--- a/src/helpers/queries.js
+++ b/src/helpers/queries.js
@@ -14,7 +14,6 @@ export const getAllQualificationLabel = {
           $in: papersLabel
         }
       })
-      .select(['metadata.qualification.label'])
       .partialIndex({
         type: 'file',
         trashed: false


### PR DESCRIPTION
In the app, two requests are executed.
The first request only retrieves the qualifications' labels and then the second one requests all qualifications's data.
If this second request is made before the first one expired (as defined by fetchPolicy), then returned data will be incorrect (only labels are returned instead of all data)