### PR TITLE
Feat/onboarding guard

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -44,6 +44,11 @@
       "type": "io.cozy.settings",
       "verbs": ["GET"]
     },
+    "mespapiers.settings": {
+      "description": "Used to manage your papers settings",
+      "type": "io.cozy.mespapiers.settings",
+      "verbs": ["GET", "POST", "PUT"]
+    },
     "permissions": {
       "description": "Required to run the konnectors",
       "type": "io.cozy.permissions",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -3,7 +3,12 @@ import React from 'react'
 import { hot } from 'react-hot-loader'
 import { Route, Switch, Redirect, HashRouter } from 'react-router-dom'
 
-import { useClient, RealTimeQueries } from 'cozy-client'
+import {
+  isQueryLoading,
+  useClient,
+  useQuery,
+  RealTimeQueries
+} from 'cozy-client'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Layout, Main, Content } from 'cozy-ui/transpiled/react/Layout'
 import { Sprite as IconSprite } from 'cozy-ui/transpiled/react/Icon'
@@ -11,6 +16,7 @@ import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import HomeWrapper from 'src/components/HomeWrapper/HomeWrapper'
 import PapersList from 'src/components/Papers/PapersList'
@@ -21,6 +27,34 @@ import { useStepperDialog } from 'src/components/Hooks/useStepperDialog'
 import StepperDialogWrapper from 'src/components/StepperDialogWrapper/StepperDialogWrapper'
 import { FormDataProvider } from 'src/components/Contexts/FormDataProvider'
 
+import { getOnboardingStatus } from 'src/helpers/queries'
+
+const OnboardedGuardedRoute = ({
+  component: Component,
+  reverseGuard = false,
+  settingsData,
+  ...rest
+}) => {
+  const onboarded = settingsData?.[0]?.onboarded
+  return (
+    <Route
+      {...rest}
+      render={props => {
+        if (reverseGuard === true && onboarded === true) {
+          return <Redirect to="/" />
+        } else if (reverseGuard !== true && onboarded !== true) {
+          return <Redirect to="/onboarding" />
+        } else {
+          return <Component {...props} />
+        }
+      }}
+    />
+  )
+}
+
+const OnboardingGuardedRoute = props =>
+  OnboardedGuardedRoute({ reverseGuard: true, ...props })
+
 export const App = () => {
   const client = useClient()
   const { t } = useI18n()
@@ -28,6 +62,11 @@ export const App = () => {
   const { BarCenter } = cozy.bar
 
   const { isStepperDialogOpen } = useStepperDialog()
+
+  const { data: settingsData, ...settingsQuery } = useQuery(
+    getOnboardingStatus.definition,
+    getOnboardingStatus.options
+  )
 
   return (
     <HashRouter>
@@ -43,31 +82,52 @@ export const App = () => {
         )}
         <Main>
           <Content className="app-content">
-            <>
-              <Switch>
-                <Route exact path="/" component={HomeWrapper} />
-                <Route
-                  exact
-                  path="/files/:fileCategory"
-                  component={PapersList}
-                />
-                <Route
-                  exact
-                  path="/file/:fileId"
-                  component={FileViewerWithQuery}
-                />
-                <Route exact path="/onboarding" component={Onboarding} />
-                <Redirect from="*" to="/" />
-              </Switch>
+            {isQueryLoading(settingsQuery) ? (
+              <Spinner
+                size="xxlarge"
+                className="u-flex u-flex-justify-center u-mt-2 u-h-5"
+              />
+            ) : (
+              <>
+                <Switch>
+                  <OnboardedGuardedRoute
+                    exact
+                    path="/"
+                    component={HomeWrapper}
+                    settingsData={settingsData}
+                  />
+                  <OnboardedGuardedRoute
+                    exact
+                    path="/files/:fileCategory"
+                    component={PapersList}
+                    settingsData={settingsData}
+                  />
+                  <OnboardedGuardedRoute
+                    exact
+                    path="/file/:fileId"
+                    component={FileViewerWithQuery}
+                    settingsData={settingsData}
+                  />
+                  <OnboardingGuardedRoute
+                    exact
+                    path="/onboarding"
+                    component={Onboarding}
+                    settingsData={settingsData}
+                  />
 
-              {isStepperDialogOpen && (
-                <FormDataProvider>
-                  <StepperDialogWrapper />
-                </FormDataProvider>
-              )}
-            </>
+                  <Redirect from="*" to="/" />
+                </Switch>
+
+                {isStepperDialogOpen && (
+                  <FormDataProvider>
+                    <StepperDialogWrapper />
+                  </FormDataProvider>
+                )}
+              </>
+            )}
           </Content>
           <RealTimeQueries doctype="io.cozy.files" />
+          <RealTimeQueries doctype="io.cozy.mespapiers.settings" />
           <Alerter t={t} />
           <ModalStack />
         </Main>

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,7 +1,7 @@
 /* global cozy */
 import React from 'react'
 import { hot } from 'react-hot-loader'
-import { Route, Switch, Redirect, HashRouter } from 'react-router-dom'
+import { Switch, Redirect, HashRouter } from 'react-router-dom'
 
 import {
   isQueryLoading,
@@ -26,34 +26,12 @@ import { ModalStack } from 'src/components/Contexts/ModalProvider'
 import { useStepperDialog } from 'src/components/Hooks/useStepperDialog'
 import StepperDialogWrapper from 'src/components/StepperDialogWrapper/StepperDialogWrapper'
 import { FormDataProvider } from 'src/components/Contexts/FormDataProvider'
+import {
+  OnboardedGuardedRoute,
+  OnboardingGuardedRoute
+} from 'src/components/Router'
 
 import { getOnboardingStatus } from 'src/helpers/queries'
-
-const OnboardedGuardedRoute = ({
-  component: Component,
-  reverseGuard = false,
-  settingsData,
-  ...rest
-}) => {
-  const onboarded = settingsData?.[0]?.onboarded
-  return (
-    <Route
-      {...rest}
-      render={props => {
-        if (reverseGuard === true && onboarded === true) {
-          return <Redirect to="/" />
-        } else if (reverseGuard !== true && onboarded !== true) {
-          return <Redirect to="/onboarding" />
-        } else {
-          return <Component {...props} />
-        }
-      }}
-    />
-  )
-}
-
-const OnboardingGuardedRoute = props =>
-  OnboardedGuardedRoute({ reverseGuard: true, ...props })
 
 export const App = () => {
   const client = useClient()

--- a/src/components/Onboarding/Onboarding.jsx
+++ b/src/components/Onboarding/Onboarding.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { useHistory } from 'react-router-dom'
+
+import { Q, useClient } from 'cozy-client'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
@@ -7,14 +8,16 @@ import Button from 'cozy-ui/transpiled/react/Button'
 import Empty from 'cozy-ui/transpiled/react/Empty'
 import HomeCloud from 'src/assets/icons/HomeCloud.svg'
 
-const Onboarding = () => {
-  const history = useHistory()
-  const { t } = useI18n()
+import { SETTINGS_DOCTYPE } from 'src/doctypes'
 
-  const onClick = () => {
-    history.push({
-      pathname: `/`
-    })
+const Onboarding = () => {
+  const { t } = useI18n()
+  const client = useClient()
+
+  const onClick = async () => {
+    const { data } = await client.query(Q(SETTINGS_DOCTYPE))
+    const settings = data?.[0] || {}
+    await client.save({ ...settings, onboarded: true, _type: SETTINGS_DOCTYPE })
   }
 
   return (

--- a/src/components/Router.jsx
+++ b/src/components/Router.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { Route, Redirect } from 'react-router-dom'
+
+export const OnboardedGuardedRoute = ({
+  component: Component,
+  reverseGuard = false,
+  settingsData,
+  ...rest
+}) => {
+  const onboarded = settingsData?.[0]?.onboarded
+  return (
+    <Route
+      {...rest}
+      render={props => {
+        if (reverseGuard === true && onboarded === true) {
+          return <Redirect to="/" />
+        } else if (reverseGuard !== true && onboarded !== true) {
+          return <Redirect to="/onboarding" />
+        } else {
+          return <Component {...props} />
+        }
+      }}
+    />
+  )
+}
+
+export const OnboardingGuardedRoute = props =>
+  OnboardedGuardedRoute({ reverseGuard: true, ...props })

--- a/src/components/Router.spec.jsx
+++ b/src/components/Router.spec.jsx
@@ -1,0 +1,116 @@
+'use strict'
+import React from 'react'
+import { render } from '@testing-library/react'
+import { Switch, Redirect } from 'react-router-dom'
+import { createHashHistory } from 'history'
+
+import AppLike from 'test/components/AppLike'
+import {
+  OnboardedGuardedRoute,
+  OnboardingGuardedRoute
+} from 'src/components/Router'
+
+const ComponentOnboarded = () => <div>ONBOARDED</div>
+const ComponentOnboarding = () => <div>ONBOARDING</div>
+
+const setup = (settingsData, history) => {
+  return render(
+    <AppLike history={history}>
+      <Switch>
+        <OnboardedGuardedRoute
+          exact
+          path="/"
+          component={ComponentOnboarded}
+          settingsData={settingsData}
+        />
+        <OnboardingGuardedRoute
+          exact
+          path="/onboarding"
+          component={ComponentOnboarding}
+          settingsData={settingsData}
+        />
+
+        <Redirect from="*" to="/" />
+      </Switch>
+    </AppLike>
+  )
+}
+
+describe('Router', () => {
+  describe('OnboardedGuardedRoute', () => {
+    it('should display route when onboarded = true', () => {
+      const settingsData = [
+        {
+          onboarded: true
+        }
+      ]
+      const { getByText } = setup(settingsData)
+
+      expect(getByText('ONBOARDED')).toBeDefined()
+    })
+
+    it('should redirect to /onboarding route when onboarded = false', () => {
+      const settingsData = [
+        {
+          onboarded: false
+        }
+      ]
+      const { getByText } = setup(settingsData)
+
+      expect(getByText('ONBOARDING')).toBeDefined()
+    })
+
+    it('should redirect to /onboarding route when no `onboarded` value is set', () => {
+      const settingsData = [
+        {
+          onboarded: false
+        }
+      ]
+      const { getByText } = setup(settingsData)
+
+      expect(getByText('ONBOARDING')).toBeDefined()
+    })
+
+    it('should redirect to /onboarding route when settingsData is undefined', () => {
+      const settingsData = undefined
+      const { getByText } = setup(settingsData)
+
+      expect(getByText('ONBOARDING')).toBeDefined()
+    })
+
+    it('should redirect to /onboarding route when settingsData is empty array', () => {
+      const settingsData = []
+      const { getByText } = setup(settingsData)
+
+      expect(getByText('ONBOARDING')).toBeDefined()
+    })
+  })
+
+  describe('OnboardingGuardedRoute', () => {
+    it('should display route route when settingsData is false', () => {
+      const settingsData = [
+        {
+          onboarded: false
+        }
+      ]
+      const history = createHashHistory()
+      history.push('/onboarding')
+      const { getByText } = setup(settingsData, history)
+
+      expect(getByText('ONBOARDING')).toBeDefined()
+    })
+
+    it('should redirect to / route when settingsData is true', () => {
+      const settingsData = [
+        {
+          onboarded: true
+        }
+      ]
+      const history = createHashHistory()
+      history.push('/onboarding')
+      const { getByText } = setup(settingsData, history)
+
+      expect(getByText('ONBOARDED')).toBeDefined()
+    })
+  })
+})

--- a/src/doctypes/index.js
+++ b/src/doctypes/index.js
@@ -2,6 +2,7 @@ export const APPS_DOCTYPE = 'io.cozy.apps'
 export const CONTACTS_DOCTYPE = 'io.cozy.contacts'
 export const FILES_DOCTYPE = 'io.cozy.files'
 export const PERMISSIONS_DOCTYPE = 'io.cozy.permissions'
+export const SETTINGS_DOCTYPE = 'io.cozy.mespapiers.settings'
 
 // the documents schema, necessary for CozyClient
 export default {

--- a/src/helpers/queries.js
+++ b/src/helpers/queries.js
@@ -1,6 +1,6 @@
 import { Q, fetchPolicies } from 'cozy-client'
 
-import { FILES_DOCTYPE, CONTACTS_DOCTYPE } from 'src/doctypes'
+import { FILES_DOCTYPE, CONTACTS_DOCTYPE, SETTINGS_DOCTYPE } from 'src/doctypes'
 import papersJSON from 'src/constants/papersDefinitions.json'
 
 const defaultFetchPolicy = fetchPolicies.olderThan(30 * 1000)
@@ -58,3 +58,11 @@ export const getContactById = id => ({
     fetchPolicy: defaultFetchPolicy
   }
 })
+
+export const getOnboardingStatus = {
+  definition: () => Q(SETTINGS_DOCTYPE),
+  options: {
+    as: `getOnboardingStatus`,
+    fetchPolicy: fetchPolicies.noFetch()
+  }
+}

--- a/test/components/AppLike.jsx
+++ b/test/components/AppLike.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { HashRouter } from 'react-router-dom'
+import { createHashHistory } from 'history'
 
 import { CozyProvider, createMockClient } from 'cozy-client'
 import I18n from 'cozy-ui/transpiled/react/I18n'
@@ -18,22 +19,25 @@ jest.mock('cozy-scanner/dist/DocumentTypeData', () => ({
   themes: [{}]
 }))
 
-const AppLike = ({ children, client }) => (
-  <CozyProvider client={client || createMockClient({})}>
-    <I18n dictRequire={() => enLocale} lang={'en'}>
-      <ScannerI18nProvider lang={'en'}>
-        <BreakpointsProvider>
-          <StepperDialogProvider>
-            <ModalProvider>
-              <PlaceholderModalProvider>
-                <HashRouter>{children}</HashRouter>
-              </PlaceholderModalProvider>
-            </ModalProvider>
-          </StepperDialogProvider>
-        </BreakpointsProvider>
-      </ScannerI18nProvider>
-    </I18n>
-  </CozyProvider>
-)
+const AppLike = ({ children, client, history }) => {
+  const hashHistory = history || createHashHistory()
+  return (
+    <CozyProvider client={client || createMockClient({})}>
+      <I18n dictRequire={() => enLocale} lang={'en'}>
+        <ScannerI18nProvider lang={'en'}>
+          <BreakpointsProvider>
+            <StepperDialogProvider>
+              <ModalProvider>
+                <PlaceholderModalProvider>
+                  <HashRouter history={hashHistory}>{children}</HashRouter>
+                </PlaceholderModalProvider>
+              </ModalProvider>
+            </StepperDialogProvider>
+          </BreakpointsProvider>
+        </ScannerI18nProvider>
+      </I18n>
+    </CozyProvider>
+  )
+}
 
 export default AppLike


### PR DESCRIPTION
On first app access we want the user to be redirected to the
`/onboarding` route

The condition for displaying this route is based on `onboarded` setting
in `io.cozy.mespapiers.settings`

Redirection is handled by a Router guard that uses cozy-client and
cozy-realtime to check `io.cozy.mespapiers.settings`