### PR TITLE
Refactor: Using cozy-client instead cozy-scanner

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@date-io/date-fns": "1",
     "@material-ui/core": "4",
     "@material-ui/pickers": "3.3.10",
-    "cozy-client": "^26.0.2",
+    "cozy-client": "^27.3.1",
     "cozy-doctypes": "1.82.2",
     "cozy-harvest-lib": "6.4.0",
     "cozy-realtime": "3.13.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "cozy-doctypes": "1.82.2",
     "cozy-harvest-lib": "6.4.0",
     "cozy-realtime": "3.13.1",
-    "cozy-scanner": "^2.0.0",
     "cozy-scripts": "5.10.0",
     "cozy-sharing": "3.5.0",
     "cozy-ui": "51.11.0",

--- a/src/components/Contexts/ScannerI18nProvider.jsx
+++ b/src/components/Contexts/ScannerI18nProvider.jsx
@@ -1,6 +1,9 @@
 import React, { createContext } from 'react'
 
-import { getBoundT } from 'cozy-scanner/dist/locales'
+import { models } from 'cozy-client'
+const {
+  locales: { getBoundT }
+} = models.document
 
 const ScannerI18nContext = createContext()
 

--- a/src/components/ImportDropdown/ImportDropdown.spec.jsx
+++ b/src/components/ImportDropdown/ImportDropdown.spec.jsx
@@ -2,11 +2,19 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 
+import { models } from 'cozy-client'
+const {
+  locales: { getBoundT }
+} = models.document
+
 import AppLike from 'test/components/AppLike'
 import People from 'cozy-ui/transpiled/react/Icons/People'
-import { getBoundT } from 'cozy-scanner/dist/locales'
 
 import ImportDropdown from 'src/components/ImportDropdown/ImportDropdown'
+
+jest.mock('cozy-client/dist/models/document/locales', () => ({
+  getBoundT: jest.fn(() => jest.fn())
+}))
 
 const setup = (label = 'national_id_card') => {
   return render(

--- a/src/components/ModelSteps/widgets/InputTextAdapter.spec.jsx
+++ b/src/components/ModelSteps/widgets/InputTextAdapter.spec.jsx
@@ -5,7 +5,7 @@ import { render, fireEvent } from '@testing-library/react'
 import AppLike from 'test/components/AppLike'
 import InputTextAdapter from 'src/components/ModelSteps/widgets/InputTextAdapter'
 
-jest.mock('cozy-scanner/dist/locales', () => ({
+jest.mock('cozy-client/dist/models/document/locales', () => ({
   getBoundT: jest.fn(() => jest.fn())
 }))
 

--- a/src/components/Papers/PaperLine.spec.jsx
+++ b/src/components/Papers/PaperLine.spec.jsx
@@ -3,7 +3,10 @@ import React from 'react'
 import { render } from '@testing-library/react'
 
 import AppLike from 'test/components/AppLike'
-import { getBoundT } from 'cozy-scanner/dist/locales'
+import { models } from 'cozy-client'
+const {
+  locales: { getBoundT }
+} = models.document
 
 import PaperLine from 'src/components/Papers/PaperLine'
 
@@ -11,6 +14,10 @@ const mockPapers = [
   { id: '00', name: 'ID card' },
   { id: '01', name: 'Passport' }
 ]
+
+jest.mock('cozy-client/dist/models/document/locales', () => ({
+  getBoundT: jest.fn(() => jest.fn())
+}))
 
 const setup = (paper = mockPapers[0]) => {
   return render(

--- a/src/components/Placeholders/FeaturedPlaceholdersList.spec.jsx
+++ b/src/components/Placeholders/FeaturedPlaceholdersList.spec.jsx
@@ -3,8 +3,10 @@ import React from 'react'
 import { render } from '@testing-library/react'
 
 import AppLike from 'test/components/AppLike'
-import { useQuery } from 'cozy-client'
-import { getBoundT } from 'cozy-scanner/dist/locales'
+import { useQuery, models } from 'cozy-client'
+const {
+  locales: { getBoundT }
+} = models.document
 
 import FeaturedPlaceholdersList from 'src/components/Placeholders/FeaturedPlaceholdersList'
 
@@ -26,6 +28,9 @@ const fakePapers = [
 ]
 
 jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
+jest.mock('cozy-client/dist/models/document/locales', () => ({
+  getBoundT: jest.fn(() => jest.fn())
+}))
 
 const setup = () => {
   return render(

--- a/src/components/Placeholders/Placeholder.spec.jsx
+++ b/src/components/Placeholders/Placeholder.spec.jsx
@@ -3,11 +3,18 @@ import React from 'react'
 import { render } from '@testing-library/react'
 
 import AppLike from 'test/components/AppLike'
-import { getBoundT } from 'cozy-scanner/dist/locales'
+import { models } from 'cozy-client'
+const {
+  locales: { getBoundT }
+} = models.document
 
 import Placeholder from 'src/components/Placeholders/Placeholder'
 import paperJSON from 'src/constants/papersDefinitions.json'
 const papersList = paperJSON.papersDefinitions
+
+jest.mock('cozy-client/dist/models/document/locales', () => ({
+  getBoundT: jest.fn(() => jest.fn())
+}))
 
 const setup = (placeholder = papersList[0]) => {
   return render(

--- a/src/components/Placeholders/PlaceholderThemesList.jsx
+++ b/src/components/Placeholders/PlaceholderThemesList.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useMemo } from 'react'
 import PropTypes from 'prop-types'
 
-import { themes } from 'cozy-scanner/dist/DocumentTypeData'
+import { models } from 'cozy-client'
 import { FixedDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import IconStack from 'cozy-ui/transpiled/react/IconStack'
 import Icon from 'cozy-ui/transpiled/react/Icon'
@@ -15,6 +15,9 @@ import ListItemIcon, {
 } from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
+const {
+  themes: { themesList }
+} = models.document
 
 import PlaceholdersList from 'src/components/Placeholders/PlaceholdersList'
 import { useScannerI18n } from 'src/components/Hooks/useScannerI18n'
@@ -52,7 +55,7 @@ const PlaceholderThemesList = ({ title, onClose }) => {
       open={true}
       content={
         <List>
-          {themes.map((theme, idx) => {
+          {themesList.map((theme, idx) => {
             return (
               <ListItem
                 button

--- a/src/components/Placeholders/PlaceholdersList.spec.jsx
+++ b/src/components/Placeholders/PlaceholdersList.spec.jsx
@@ -2,8 +2,6 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 
-import { getBoundT } from 'cozy-scanner/dist/locales'
-
 import AppLike from 'test/components/AppLike'
 import PlaceholdersList from 'src/components/Placeholders/PlaceholdersList'
 
@@ -13,18 +11,14 @@ const fakeQualificationItems = [
   }
 ]
 
-jest.mock('cozy-scanner/dist/locales', () => ({
-  getBoundT: jest.fn(() => jest.fn())
+jest.mock('cozy-client/dist/models/document/locales', () => ({
+  getBoundT: jest.fn().mockReturnValue(() => 'New paper - Passeport')
 }))
 
 const setup = () => {
   return render(
     <AppLike>
-      <PlaceholdersList
-        title="passport"
-        currentQualifItems={fakeQualificationItems}
-        onBack={jest.fn()}
-      />
+      <PlaceholdersList currentQualifItems={fakeQualificationItems} />
     </AppLike>
   )
 }
@@ -36,8 +30,7 @@ describe('PlaceholdersList components:', () => {
     expect(container).toBeDefined()
   })
 
-  xit('should display header title with theme', () => {
-    getBoundT.mockReturnValueOnce(() => 'Passeport')
+  it('should display header title with theme', () => {
     const { getByText } = setup()
 
     expect(getByText('New paper - Passeport'))

--- a/src/components/Viewer/Panel/Qualification.jsx
+++ b/src/components/Viewer/Panel/Qualification.jsx
@@ -1,12 +1,15 @@
 import React, { useState, useEffect } from 'react'
 
-import { getBoundT } from 'cozy-scanner/dist/locales'
+import { models } from 'cozy-client'
 import { useClient } from 'cozy-client'
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
 import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import withLocales from 'cozy-ui/transpiled/react/I18n/withLocales'
+const {
+  locales: { getBoundT }
+} = models.document
 
 import fr from '../locales/fr.json'
 import en from '../locales/fr.json'

--- a/test/components/AppLike.jsx
+++ b/test/components/AppLike.jsx
@@ -12,10 +12,7 @@ import { PlaceholderModalProvider } from 'src/components/Contexts/PlaceholderMod
 import { ScannerI18nProvider } from 'src/components/Contexts/ScannerI18nProvider'
 import enLocale from 'src/locales/en.json'
 
-jest.mock('cozy-scanner/dist/locales', () => ({
-  getBoundT: jest.fn(() => jest.fn())
-}))
-jest.mock('cozy-scanner/dist/DocumentTypeData', () => ({
+jest.mock('cozy-client/dist/models/document/documentTypeData', () => ({
   themes: [{}]
 }))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3902,13 +3902,6 @@ cozy-device-helper@^1.12.0, cozy-device-helper@^1.7.3:
   dependencies:
     lodash "^4.17.19"
 
-cozy-device-helper@^1.13.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-1.13.0.tgz#b1de05d1c84e869b71f41476ac6e9694b939db44"
-  integrity sha512-7GmDVahgzglMIMJ5aFiai930zrt7/elHqDPOdAmgOYfF1I+oA0MChh+xFl0ZO9AZN2LWyV3VDXEmi6Cjjvludg==
-  dependencies:
-    lodash "^4.17.19"
-
 cozy-doctypes@1.82.2, cozy-doctypes@^1.82.2:
   version "1.82.2"
   resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.82.2.tgz#7c7d6f44e3aaee18ba51253468e84d2d1a70fde6"
@@ -3985,13 +3978,6 @@ cozy-release@1.10.0:
   integrity sha512-x1XldRwxiZEjGAij6GdJq2ZUckkhNXoOTlfc9299GqaYk0SM+fADW8rmiPUQ0F0/TXy/g7ej78c9EWdstmZ+iw==
   dependencies:
     exec-sh "0.3.2"
-
-cozy-scanner@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-scanner/-/cozy-scanner-2.0.0.tgz#c6c87ce60d61707628e9bc81ca552cfbea8f313b"
-  integrity sha512-T7gBf9w8eYqGvB+lP+1G60vwMExnuojow5Wa3ZfYgH4oT3TDvq+YrGG4j5vuZBwXsgSFIPF24fRGYAkAPjmvSQ==
-  dependencies:
-    cozy-device-helper "^1.13.0"
 
 cozy-scripts@5.10.0:
   version "5.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2472,6 +2472,18 @@ array.prototype.flat@^1.2.3:
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.1"
 
+array.prototype.foreach@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array.prototype.foreach/-/array.prototype.foreach-1.0.2.tgz#592b177c8d6abb84e14de1649eb6e7cc5eb9c9ae"
+  integrity sha512-gCOgyBKIaFL5hekfQLhsNmF0TY4Y5JdtOyFKtbSpL72oiCAZ9Zi7TFvcfSsM1LnBFMog1RYVJF0PHgtnY+U5nA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.0"
+    es-array-method-boxes-properly "^1.0.0"
+    get-intrinsic "^1.1.1"
+    is-string "^1.0.7"
+
 asn1.js@^5.2.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-5.4.1.tgz#11a980b84ebb91781ce35b0fdc2ee294e3783f07"
@@ -3849,10 +3861,10 @@ cozy-client@13.8.3:
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
 
-cozy-client@^26.0.2:
-  version "26.0.2"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-26.0.2.tgz#e4af51d1b5afbf86d6ac1d32438f482c905a187c"
-  integrity sha512-Ofc5MEQLKh7fld1tty0bm/1ZI/K0AUjn9NusFfScv7ij+16kWN6GQevWm6uEV2OK8ev9L8oS2FT4IonK0LsFBw==
+cozy-client@^27.3.1:
+  version "27.3.1"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-27.3.1.tgz#acba38b66a699557f66d6cf3db0624c247a17473"
+  integrity sha512-tsK13rzun5RIrusVvud85KI2sLN8MqYoacwr6PhHJgLtkGED8UcMoErhBmZS2HIIih9dHVPPZTNbTSlAsoW2NA==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
@@ -3861,11 +3873,12 @@ cozy-client@^26.0.2:
     cozy-device-helper "^1.12.0"
     cozy-flags "2.7.1"
     cozy-logger "^1.6.0"
-    cozy-stack-client "^26.0.0"
+    cozy-stack-client "^27.1.0"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
     microee "^0.0.6"
     node-fetch "^2.6.1"
+    node-polyglot "2.4.2"
     open "7.4.2"
     prop-types "^15.6.2"
     react-redux "^7.2.0"
@@ -4063,10 +4076,10 @@ cozy-stack-client@^13.8.3:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^26.0.0:
-  version "26.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-26.0.0.tgz#172b031429943984b4293300eb67e345ab95fc63"
-  integrity sha512-UpUuKL+RNYkCOLmL45STKAnmVUzhf6cQ0A9mSHYP9DCPdrt3B6M90E2sRdYg47NLt0Pbb3hvEO3QOpL/WVi2sg==
+cozy-stack-client@^27.1.0:
+  version "27.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-27.1.0.tgz#facc296e99b666c5fd56e449c65f95decac6ec8b"
+  integrity sha512-fcZJpoUd5E+rDRwiuQ5Whjg+jJlxlC/xpmDjdph0mlyDshAP5B8pdNpPIm7MYhnUbcS97JEZHLcQntdKZnHz5Q==
   dependencies:
     cozy-flags "2.7.1"
     detect-node "^2.0.4"
@@ -4963,6 +4976,32 @@ es-abstract@^1.17.2, es-abstract@^1.17.4, es-abstract@^1.18.0, es-abstract@^1.18
     is-regex "^1.1.3"
     is-string "^1.0.6"
     object-inspect "^1.10.3"
+    object-keys "^1.1.1"
+    object.assign "^4.1.2"
+    string.prototype.trimend "^1.0.4"
+    string.prototype.trimstart "^1.0.4"
+    unbox-primitive "^1.0.1"
+
+es-abstract@^1.19.0, es-abstract@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.1.tgz#d4885796876916959de78edaa0df456627115ec3"
+  integrity sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    get-intrinsic "^1.1.1"
+    get-symbol-description "^1.0.0"
+    has "^1.0.3"
+    has-symbols "^1.0.2"
+    internal-slot "^1.0.3"
+    is-callable "^1.2.4"
+    is-negative-zero "^2.0.1"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.1"
+    is-string "^1.0.7"
+    is-weakref "^1.0.1"
+    object-inspect "^1.11.0"
     object-keys "^1.1.1"
     object.assign "^4.1.2"
     string.prototype.trimend "^1.0.4"
@@ -5948,6 +5987,14 @@ get-stream@^5.0.0:
   dependencies:
     pump "^3.0.0"
 
+get-symbol-description@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.0.0.tgz#7fdb81c900101fbd564dd5f1a30af5aadc1e58d6"
+  integrity sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.1"
+
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
@@ -6120,6 +6167,13 @@ has-symbols@^1.0.1, has-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-tostringtag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
+  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
+  dependencies:
+    has-symbols "^1.0.2"
 
 has-value@^0.3.1:
   version "0.3.1"
@@ -6786,6 +6840,11 @@ is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.1.5, is-callable@^1.2.3:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
   integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
 
+is-callable@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
+  integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
+
 is-ci@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
@@ -6981,10 +7040,23 @@ is-regex@^1.0.4, is-regex@^1.0.5, is-regex@^1.1.0, is-regex@^1.1.3:
     call-bind "^1.0.2"
     has-symbols "^1.0.2"
 
+is-regex@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
+  integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
 is-resolvable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
   integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
+
+is-shared-array-buffer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz#97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6"
+  integrity sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==
 
 is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
@@ -7000,6 +7072,13 @@ is-string@^1.0.5, is-string@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.6.tgz#3fe5d5992fb0d93404f32584d4b0179a71b54a5f"
   integrity sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==
+
+is-string@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
+  integrity sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==
+  dependencies:
+    has-tostringtag "^1.0.0"
 
 is-subset@^0.1.1:
   version "0.1.1"
@@ -7022,6 +7101,13 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
+
+is-weakref@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.1.tgz#842dba4ec17fa9ac9850df2d6efbc1737274f2a2"
+  integrity sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==
+  dependencies:
+    call-bind "^1.0.0"
 
 is-whitespace-character@^1.0.0:
   version "1.0.4"
@@ -8761,6 +8847,17 @@ node-notifier@^8.0.0:
     uuid "^8.3.0"
     which "^2.0.2"
 
+node-polyglot@2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/node-polyglot/-/node-polyglot-2.4.2.tgz#e4876e6710b70dc00b1351a9a68de4af47a5d61d"
+  integrity sha512-AgTVpQ32BQ5XPI+tFHJ9bCYxWwSLvtmEodX8ooftFhEuyCgBG6ijWulIVb7pH3THigtgvc9uLiPn0IO51KHpkg==
+  dependencies:
+    array.prototype.foreach "^1.0.0"
+    has "^1.0.3"
+    object.entries "^1.1.4"
+    string.prototype.trim "^1.2.4"
+    warning "^4.0.3"
+
 node-polyglot@^2.2.2, node-polyglot@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/node-polyglot/-/node-polyglot-2.4.0.tgz#0d2717ed06640d9ff48a2aebe8d13e39ef03518f"
@@ -8890,6 +8987,11 @@ object-inspect@^1.10.3, object-inspect@^1.7.0, object-inspect@^1.9.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.3.tgz#c2aa7d2d09f50c99375704f7a0adf24c5782d369"
   integrity sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==
 
+object-inspect@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
+  integrity sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==
+
 object-is@^1.0.1, object-is@^1.0.2, object-is@^1.1.2:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
@@ -8928,6 +9030,15 @@ object.entries@^1.1.0, object.entries@^1.1.1, object.entries@^1.1.2:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.18.2"
+
+object.entries@^1.1.4:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.5.tgz#e1acdd17c4de2cd96d5a08487cfb9db84d881861"
+  integrity sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.1"
 
 object.fromentries@^2.0.0, object.fromentries@^2.0.2, object.fromentries@^2.0.3:
   version "2.0.4"
@@ -11477,6 +11588,15 @@ string.prototype.trim@^1.1.2, string.prototype.trim@^1.2.1:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.2"
+
+string.prototype.trim@^1.2.4:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.5.tgz#a587bcc8bfad8cb9829a577f5de30dd170c1682c"
+  integrity sha512-Lnh17webJVsD6ECeovpVN17RlAKjmz4rF9S+8Y45CkMc/ufVpTkU3vZIyIC7sllQ1FCvObZnnCdNs/HXTUOTlg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.1"
 
 string.prototype.trimend@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
From version 27.3.1 of cozy-client, we can do without cozy-scanner for themes and translations of qualifications