### PR TITLE
feat: Move metadata

### DIFF
--- a/src/components/Contexts/FormDataProvider.jsx
+++ b/src/components/Contexts/FormDataProvider.jsx
@@ -133,11 +133,14 @@ const savePdfToCozy = async ({
 
   const newMetadata = {
     qualification: {
-      ...qualification,
-      ...pdfMetadata,
-      ...formMetadata,
-      featureDate
-    }
+      ...qualification
+    },
+    ...pdfMetadata,
+    ...formMetadata,
+    datetime: formMetadata[featureDate]
+      ? formMetadata[featureDate]
+      : pdf.getCreationDate(),
+    datetimeLabel: formMetadata[featureDate] ? featureDate : 'datetime'
   }
 
   const date =

--- a/src/components/Papers/PaperLine.jsx
+++ b/src/components/Papers/PaperLine.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useRef } from 'react'
+import React, { useState, useRef } from 'react'
 import { useHistory } from 'react-router-dom'
 import PropTypes from 'prop-types'
 
@@ -21,7 +21,6 @@ import DotsIcon from 'cozy-ui/transpiled/react/Icons/Dots'
 import IconPdf from 'cozy-ui/transpiled/react/Icons/FileTypePdf'
 import CardMedia from 'cozy-ui/transpiled/react/CardMedia'
 
-import { usePapersDefinitions } from 'src/components/Hooks/usePapersDefinitions'
 import { ActionsItems } from 'src/components/Actions/ActionsItems'
 import { getThumbnailLink } from 'src/utils/getThumbnailLink'
 
@@ -33,26 +32,13 @@ const PaperLine = ({ paper, divider, actions }) => {
   const { f, t } = useI18n()
   const { isMobile } = useBreakpoints()
   const actionBtnRef = useRef()
-  const { papersDefinitions } = usePapersDefinitions()
   const client = useClient()
   const [imgOnError, setImgOnError] = useState(false)
 
   const [optionFile, setOptionFile] = useState(false)
-  const paperDefinition = useMemo(
-    () =>
-      papersDefinitions.find(
-        p => p.label === paper?.metadata?.qualification?.label
-      ),
-    [paper, papersDefinitions]
-  )
-  const papersFeatureDate = useMemo(
-    () =>
-      paperDefinition?.featureDate &&
-      paper?.metadata?.qualification?.[paperDefinition.featureDate],
-    [paper, paperDefinition]
-  )
+
   const paperLabel = paper?.metadata?.qualification?.page
-  const paperDate = f(papersFeatureDate || paper.created_at, 'DD/MM/YYYY')
+  const paperDate = f(paper?.metadata?.datetime, 'DD/MM/YYYY')
 
   const hideActionsMenu = () => setOptionFile(false)
   const toggleActionsMenu = () => setOptionFile(prev => !prev)

--- a/src/components/Viewer/Panel/Qualification.jsx
+++ b/src/components/Viewer/Panel/Qualification.jsx
@@ -23,9 +23,14 @@ const Qualification = ({ file = {}, t, f, lang }) => {
   const client = useClient()
   const [currentUser, setCurrentUser] = useState(null)
 
-  const { name: filename, metadata = {}, created_at } = file
-  const { qualification = {} } = metadata
-  const { label, page: pageLabel, featureDate } = qualification
+  const { name: filename, metadata = {} } = file
+  const {
+    qualification = {},
+    page: pageLabel,
+    datetime,
+    datetimeLabel
+  } = metadata
+  const { label } = qualification
 
   // TODO Improve it when other contact choices are needed
   useEffect(() => {
@@ -46,32 +51,25 @@ const Qualification = ({ file = {}, t, f, lang }) => {
       <ListItem>
         <Typography variant={'h6'}>{t('viewer.panel.title')}</Typography>
       </ListItem>
-      {featureDate && (
-        <ListItem>
-          <ListItemText
-            disableTypography
-            primary={
-              <Typography variant={'caption'}>
-                {t(
-                  `viewer.panel.qualification.date.title.${
-                    qualification[featureDate] ? featureDate : 'addedOn'
-                  }`
-                )}
-              </Typography>
-            }
-            secondary={
-              <Typography variant={'body1'}>
-                {f(
-                  qualification[featureDate]
-                    ? qualification[featureDate]
-                    : created_at,
-                  'DD/MM/YYYY'
-                )}
-              </Typography>
-            }
-          />
-        </ListItem>
-      )}
+      <ListItem>
+        <ListItemText
+          disableTypography
+          primary={
+            <Typography variant={'caption'}>
+              {t(
+                `viewer.panel.qualification.date.title.${
+                  datetimeLabel === 'datetime' ? 'addedOn' : datetimeLabel
+                }`
+              )}
+            </Typography>
+          }
+          secondary={
+            <Typography variant={'body1'}>
+              {f(datetime, 'DD/MM/YYYY')}
+            </Typography>
+          }
+        />
+      </ListItem>
       <ListItem>
         <ListItemText
           disableTypography


### PR DESCRIPTION
The attributes that are not qualification attributes should be removed from the `qualification:` object, but remain in the `metadata`