### PR TITLE
fix: Displaying the contact list on Safari

### DIFF
--- a/src/components/ModelSteps/Contact.jsx
+++ b/src/components/ModelSteps/Contact.jsx
@@ -81,9 +81,9 @@ const Contact = () => {
 
   return (
     <>
-      <Paper elevation={2} className={'u-mt-1'}>
+      <Paper elevation={2} className={'u-mt-1 u-mh-half'}>
         <List>
-          <div className={'u-mah-5 u-ov-scroll'}>
+          <div className={'u-mah-5 u-ov-auto'}>
             {contactsList.map(contact => (
               <ListItem
                 key={contact._id}


### PR DESCRIPTION
`u-ov-scroll` creates an unwanted margin on Safari

Add a vertical margin on the Paper component to display the box-shadow on the sides