### PR TITLE
refactor: Management of the InputText constraints

### DIFF
--- a/src/components/ModelSteps/Information.jsx
+++ b/src/components/ModelSteps/Information.jsx
@@ -41,13 +41,14 @@ const Information = ({ currentStep }) => {
   const inputs = useMemo(
     () =>
       attributes
-        ? attributes.map(({ name, type, inputLabel }) => {
-            switch (type) {
+        ? attributes.map(attrs => {
+            switch (attrs.type) {
               case 'date':
                 return function InputDate(props) {
                   return (
                     <InputDateAdapter
-                      attrs={{ metadata: formData.metadata, name, inputLabel }}
+                      attrs={attrs}
+                      defaultValue={formData.metadata[attrs.name]}
                       setValue={setValue}
                       setValidInput={setValidInput}
                       setIsFocus={setIsFocus}
@@ -59,12 +60,8 @@ const Information = ({ currentStep }) => {
                 return function InputText(props) {
                   return (
                     <InputTextAdapter
-                      attrs={{
-                        metadata: formData.metadata,
-                        name,
-                        inputLabel,
-                        type
-                      }}
+                      attrs={attrs}
+                      defaultValue={formData.metadata[attrs.name]}
                       setValue={setValue}
                       setValidInput={setValidInput}
                       setIsFocus={setIsFocus}

--- a/src/components/ModelSteps/widgets/InputDateAdapter.jsx
+++ b/src/components/ModelSteps/widgets/InputDateAdapter.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import DateFnsUtils from '@date-io/date-fns'
+import PropTypes from 'prop-types'
 import {
   MuiPickersUtilsProvider,
   KeyboardDatePicker
@@ -23,17 +24,18 @@ const useStyles = makeStyles(() => ({
 
 const InputDateAdapter = ({
   attrs,
+  defaultValue,
   setValue,
   setValidInput,
   setIsFocus,
   idx
 }) => {
-  const { name, inputLabel, metadata } = attrs
+  const { name, inputLabel } = attrs
   const { t, lang } = useI18n()
   const classes = useStyles()
   const [locales, setLocales] = useState('')
   const [isValidDate, setIsValidDate] = useState(true)
-  const [selectedDate, setSelectedDate] = useState(metadata[name] || null)
+  const [selectedDate, setSelectedDate] = useState(defaultValue || null)
   const [displayHelper, setDisplayHelper] = useState(false)
 
   useEffect(() => {
@@ -106,6 +108,24 @@ const InputDateAdapter = ({
       />
     </MuiPickersUtilsProvider>
   )
+}
+
+const attrsProptypes = PropTypes.shape({
+  name: PropTypes.string,
+  inputLabel: PropTypes.string,
+  type: PropTypes.string,
+  required: PropTypes.bool,
+  minLength: PropTypes.number,
+  maxLength: PropTypes.number
+})
+
+InputDateAdapter.propTypes = {
+  attrs: attrsProptypes.isRequired,
+  defaultValue: PropTypes.string,
+  setValue: PropTypes.func.isRequired,
+  setValidInput: PropTypes.func.isRequired,
+  setIsFocus: PropTypes.func.isRequired,
+  idx: PropTypes.number
 }
 
 export default InputDateAdapter

--- a/src/components/ModelSteps/widgets/InputTextAdapter.spec.jsx
+++ b/src/components/ModelSteps/widgets/InputTextAdapter.spec.jsx
@@ -9,19 +9,29 @@ jest.mock('cozy-client/dist/models/document/locales', () => ({
   getBoundT: jest.fn(() => jest.fn())
 }))
 
-const mockAttrs = (type = '', value = 'fakeValue') => ({
+const mockAttrs = ({
+  type = '',
+  maxLength = 0,
+  minLength = 0,
+  required = false,
+  defaultValue = 'fakeValue'
+}) => ({
   name: 'name01',
   inputLabel: 'PaperJSON.IDCard.number.inputLabel',
-  metadata: { name01: value },
+  defaultValue,
+  required,
+  minLength,
+  maxLength,
   type
 })
 
-const setup = (attrs = mockAttrs()) => {
-  const value = attrs.metadata.name01
+const setup = (attrs = mockAttrs({})) => {
+  const value = attrs.defaultValue
   const container = render(
     <AppLike>
       <InputTextAdapter
         attrs={attrs}
+        defaultValue={value}
         setValue={jest.fn()}
         setValidInput={jest.fn()}
       />
@@ -43,14 +53,14 @@ describe('InputTextAdapter components:', () => {
   })
 
   it('should have a value of 5 letters', () => {
-    const { input } = setup(mockAttrs(':5'))
+    const { input } = setup(mockAttrs({ maxLength: 5 }))
     fireEvent.change(input, { target: { value: 'abcde' } })
 
     expect(input.value).toBe('abcde')
   })
 
-  it('should have a value of "fakeValue"', () => {
-    const { input } = setup(mockAttrs(':5'))
+  it('should have a maximum of 5 characters', () => {
+    const { input } = setup(mockAttrs({ maxLength: 5 }))
     fireEvent.change(input, { target: { value: 'abcdefgh' } })
     expect(input.value).toBe('fakeValue')
 
@@ -59,9 +69,9 @@ describe('InputTextAdapter components:', () => {
   })
 
   it('should have a value of 5 digits', () => {
-    const { input } = setup(mockAttrs('Number:5', '789'))
+    const { input } = setup(mockAttrs({ type: 'number', maxLength: 5 }))
     fireEvent.change(input, { target: { value: '12345' } })
 
-    expect(input.value).toBe('12345')
+    expect(parseInt(input.value, 10)).toBe(12345)
   })
 })

--- a/src/constants/papersDefinitions.json
+++ b/src/constants/papersDefinitions.json
@@ -260,7 +260,10 @@
           "attributes": [
             {
               "name": "labelGivenByUser",
-              "type": "*Text",
+              "type": "text",
+              "required": true,
+              "minLength": 3,
+              "maxLength": 15,
               "inputLabel": "PaperJSON.generic.renameFile.inputLabel"
             }
           ]

--- a/src/utils/input.js
+++ b/src/utils/input.js
@@ -1,65 +1,70 @@
 import log from 'cozy-logger'
-const NUMBER = 'Number'
-const TEXT = 'Text'
+
+/**
+ * @typedef {object} MakeConstraintsOfInputParam
+ * @property {'text'|'number'} [type] - A string specifying the type of input
+ * @property {boolean} [required] - Indicates that the user must specify a value for the input
+ * @property {object} [minLength] - Defines the minimum number of characters can enter into the input
+ * @property {string} [maxLength] - Defines the maximum number of characters can enter into the input
+ */
 
 /**
  * Make type and length properties
- * @param {string} typeDefinition - Definition of type & length of the input
+ * @param {MakeConstraintsOfInputParam} attrs - Definition of type & length of the input
  * @example
  * // For make input number with contraint length to 12
- * makeInputTypeAndLength("Number:12")
+ * makeConstraintsOfInput({ type: 'number', minLength: 12, maxLength: 12 })
  * // For make input text with no contraint length
- * makeInputTypeAndLength("Text")
- * // For make input number with contraint length to 12 & required
- * makeInputTypeAndLength("*Number:12")
+ * makeConstraintsOfInput()
+ * // For make input number with contraint length to 12 & required & size to 15
+ * makeConstraintsOfInput({ type: 'number', required: true, minLength: 12, maxLength: 12, size: 15 })
+ *
+ * @returns {{ inputType: string, expectedLength: { min: number, max: number }, isRequired: boolean }}
  */
-export const makeInputTypeAndLength = typeDefinition => {
-  const isRequired = typeDefinition[0] === '*'
-  const [type = typeDefinition, maxLength] = typeDefinition
-    .replace('*', '')
-    .split(':')
+export const makeConstraintsOfInput = attrs => {
+  const { type = '', required = false, minLength = 0, maxLength = 0 } =
+    attrs || {}
 
-  const result = { inputType: '', expectedLength: 0, isRequired }
-  switch (type) {
-    case NUMBER:
-      result.inputType = NUMBER.toLowerCase()
-      break
-    case TEXT:
-      result.inputType = TEXT.toLowerCase()
-      break
-    default:
-      log(
-        'warn',
-        '"type" in "attributes" property is not defined or unexpected, "type" set to "text" by default'
-      )
-      result.inputType = TEXT.toLowerCase()
-      break
+  const acceptedTypes = ['number', 'text']
+
+  const result = {
+    inputType: '',
+    expectedLength: {
+      min: maxLength > 0 ? Math.min(minLength, maxLength) : minLength,
+      max: maxLength > 0 ? Math.max(minLength, maxLength) : maxLength
+    },
+    isRequired: required
   }
 
-  if (maxLength) result.expectedLength = parseInt(maxLength, 10)
+  if (!acceptedTypes.includes(type.toLowerCase())) {
+    log(
+      'warn',
+      `'type' in 'attributes' property is not defined or unexpected, 'type' set to ${
+        acceptedTypes[1]
+      } by default'`
+    )
+    result.inputType = acceptedTypes[1]
+  } else result.inputType = type
 
   return result
 }
 
 /**
  * @param {number} valueLength - Length of input value
- * @param {boolean} isRequired - If value is required
  * @param {number} expectedLength - Expected length of the input value
+ * @param {boolean} isRequired - If value is required
  * @returns {boolean}
  */
 export const checkConstraintsOfIinput = (
   valueLength,
-  isRequired,
-  expectedLength
+  expectedLength,
+  isRequired
 ) => {
-  let isValid = false
+  const { min, max } = expectedLength
 
-  if (expectedLength) {
-    isValid =
-      valueLength === expectedLength || (valueLength === 0 && !isRequired)
-  } else {
-    isValid = isRequired ? valueLength > 0 : true
-  }
-
-  return isValid
+  return [
+    valueLength >= min,
+    max > 0 ? valueLength <= max : true,
+    isRequired ? valueLength > 0 : true
+  ].every(Boolean)
 }

--- a/src/utils/input.spec.js
+++ b/src/utils/input.spec.js
@@ -1,51 +1,56 @@
 import {
   checkConstraintsOfIinput,
-  makeInputTypeAndLength
+  makeConstraintsOfInput
 } from 'src/utils/input'
 
 describe('Input Utils', () => {
   describe('makeInputTypeAndLength', () => {
     it.each`
-      opts            | result
-      ${'Number'}     | ${{ inputType: 'number', expectedLength: 0, isRequired: false }}
-      ${'Number:'}    | ${{ inputType: 'number', expectedLength: 0, isRequired: false }}
-      ${'Number:0'}   | ${{ inputType: 'number', expectedLength: 0, isRequired: false }}
-      ${'Number:10'}  | ${{ inputType: 'number', expectedLength: 10, isRequired: false }}
-      ${''}           | ${{ inputType: 'text', expectedLength: 0, isRequired: false }}
-      ${'Other:'}     | ${{ inputType: 'text', expectedLength: 0, isRequired: false }}
-      ${'Text'}       | ${{ inputType: 'text', expectedLength: 0, isRequired: false }}
-      ${'Text:10'}    | ${{ inputType: 'text', expectedLength: 10, isRequired: false }}
-      ${'String:10'}  | ${{ inputType: 'text', expectedLength: 10, isRequired: false }}
-      ${':10'}        | ${{ inputType: 'text', expectedLength: 10, isRequired: false }}
-      ${'*'}          | ${{ inputType: 'text', expectedLength: 0, isRequired: true }}
-      ${'*:10'}       | ${{ inputType: 'text', expectedLength: 10, isRequired: true }}
-      ${'*Text:10'}   | ${{ inputType: 'text', expectedLength: 10, isRequired: true }}
-      ${'*Number'}    | ${{ inputType: 'number', expectedLength: 0, isRequired: true }}
-      ${'*Number:10'} | ${{ inputType: 'number', expectedLength: 10, isRequired: true }}
+      attrs                                                                | result
+      ${{ type: 'number' }}                                                | ${{ inputType: 'number', expectedLength: { min: 0, max: 0 }, isRequired: false }}
+      ${{ type: 'number', required: false, minLength: 0, maxLength: 0 }}   | ${{ inputType: 'number', expectedLength: { min: 0, max: 0 }, isRequired: false }}
+      ${{ type: 'number', required: false, minLength: 10, maxLength: 0 }}  | ${{ inputType: 'number', expectedLength: { min: 10, max: 0 }, isRequired: false }}
+      ${{ type: 'number', required: false, minLength: 0, maxLength: 10 }}  | ${{ inputType: 'number', expectedLength: { min: 0, max: 10 }, isRequired: false }}
+      ${{ type: 'number', required: false, minLength: 5, maxLength: 10 }}  | ${{ inputType: 'number', expectedLength: { min: 5, max: 10 }, isRequired: false }}
+      ${{ type: 'number', required: false, minLength: 10, maxLength: 10 }} | ${{ inputType: 'number', expectedLength: { min: 10, max: 10 }, isRequired: false }}
+      ${{ type: 'number', required: true, minLength: 0, maxLength: 0 }}    | ${{ inputType: 'number', expectedLength: { min: 0, max: 0 }, isRequired: true }}
+      ${{ type: 'number', required: true, minLength: 20, maxLength: 10 }}  | ${{ inputType: 'number', expectedLength: { min: 10, max: 20 }, isRequired: true }}
+      ${undefined}                                                         | ${{ inputType: 'text', expectedLength: { min: 0, max: 0 }, isRequired: false }}
+      ${{ type: 'text' }}                                                  | ${{ inputType: 'text', expectedLength: { min: 0, max: 0 }, isRequired: false }}
+      ${{ type: 'text', required: false, minLength: 0, maxLength: 0 }}     | ${{ inputType: 'text', expectedLength: { min: 0, max: 0 }, isRequired: false }}
+      ${{ type: 'text', required: false, minLength: 10, maxLength: 0 }}    | ${{ inputType: 'text', expectedLength: { min: 10, max: 0 }, isRequired: false }}
+      ${{ type: 'text', required: false, minLength: 0, maxLength: 10 }}    | ${{ inputType: 'text', expectedLength: { min: 0, max: 10 }, isRequired: false }}
+      ${{ type: 'text', required: false, minLength: 5, maxLength: 10 }}    | ${{ inputType: 'text', expectedLength: { min: 5, max: 10 }, isRequired: false }}
+      ${{ type: 'text', required: false, minLength: 10, maxLength: 10 }}   | ${{ inputType: 'text', expectedLength: { min: 10, max: 10 }, isRequired: false }}
+      ${{ type: 'text', required: true, minLength: 0, maxLength: 0 }}      | ${{ inputType: 'text', expectedLength: { min: 0, max: 0 }, isRequired: true }}
+      ${{ type: 'text', required: true, minLength: 20, maxLength: 10 }}    | ${{ inputType: 'text', expectedLength: { min: 10, max: 20 }, isRequired: true }}
     `(
-      `should return $result when passed argument: $opts`,
-      ({ opts, result }) => {
-        expect(makeInputTypeAndLength(opts)).toEqual(result)
+      `should return $result when passed argument: $attrs`,
+      ({ attrs, result }) => {
+        expect(makeConstraintsOfInput(attrs)).toEqual(result)
       }
     )
   })
 
   describe('checkInputConstraints', () => {
     it.each`
-      valueLength | isRequired | expectedLength | result
-      ${0}        | ${false}   | ${0}           | ${true}
-      ${10}       | ${false}   | ${0}           | ${true}
-      ${0}        | ${true}    | ${0}           | ${false}
-      ${10}       | ${true}    | ${0}           | ${true}
-      ${0}        | ${false}   | ${10}          | ${true}
-      ${5}        | ${false}   | ${10}          | ${false}
-      ${10}       | ${true}    | ${10}          | ${true}
-      ${5}        | ${true}    | ${10}          | ${false}
+      valueLength | expectedLength          | isRequired | result
+      ${0}        | ${{ min: 0, max: 0 }}   | ${false}   | ${true}
+      ${0}        | ${{ min: 0, max: 20 }}  | ${false}   | ${true}
+      ${0}        | ${{ min: 10, max: 0 }}  | ${true}    | ${false}
+      ${0}        | ${{ min: 10, max: 20 }} | ${true}    | ${false}
+      ${10}       | ${{ min: 0, max: 0 }}   | ${false}   | ${true}
+      ${10}       | ${{ min: 0, max: 20 }}  | ${false}   | ${true}
+      ${21}       | ${{ min: 0, max: 20 }}  | ${false}   | ${false}
+      ${0}        | ${{ min: 10, max: 0 }}  | ${true}    | ${false}
+      ${10}       | ${{ min: 10, max: 0 }}  | ${true}    | ${true}
+      ${0}        | ${{ min: 10, max: 20 }} | ${true}    | ${false}
+      ${15}       | ${{ min: 10, max: 20 }} | ${true}    | ${true}
     `(
-      `should return $result when passed argument: ($valueLength, $isRequired, $expectedLength)`,
-      ({ valueLength, isRequired, expectedLength, result }) => {
+      `should return $result when passed argument: ($valueLength, $expectedLength, $isRequired)`,
+      ({ valueLength, expectedLength, isRequired, result }) => {
         expect(
-          checkConstraintsOfIinput(valueLength, isRequired, expectedLength)
+          checkConstraintsOfIinput(valueLength, expectedLength, isRequired)
         ).toEqual(result)
       }
     )


### PR DESCRIPTION
For a better maintainability, the definition of Inputs in the configuration file should follow the official API for inputs
(At least for the constraint rules)