### PR TITLE
fix: Add fetchMore function for load all papers

### DIFF
--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -21,10 +21,13 @@ const Home = () => {
     () => getAllQualificationLabel(papersDefinitions),
     [papersDefinitions]
   )
-  const { data: allPapers, hasMore: hasMorePapers, ...restPapers } = useQuery(
-    allQualificationLabel.definition,
-    allQualificationLabel.options
-  )
+  const {
+    data: allPapers,
+    hasMore: hasMorePapers,
+    fetchMore: fetchMorePapers,
+    ...restPapers
+  } = useQuery(allQualificationLabel.definition, allQualificationLabel.options)
+
   const isQueryOver = useMemo(
     () =>
       !isQueryLoading(restPapers) &&
@@ -32,6 +35,8 @@ const Home = () => {
       !hasMorePapers,
     [hasMorePapers, restPapers]
   )
+
+  if (hasMorePapers) fetchMorePapers()
 
   const featuredPlaceholders = useMemo(
     () =>


### PR DESCRIPTION
When we have more than 100 papers (maximum limit), we need `fetchMorePapers` to get the rest.
We need to fetch all the papers for the construction of the Home.