### PR TITLE
feat: Add a confirm modal

### DIFF
--- a/src/components/ModelSteps/AcquisitionResult.jsx
+++ b/src/components/ModelSteps/AcquisitionResult.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, memo } from 'react'
 import PropTypes from 'prop-types'
 
 import Card from 'cozy-ui/transpiled/react/Card'
@@ -122,4 +122,4 @@ AcquisitionResult.propTypes = {
   currentStep: PaperDefinitionsStepPropTypes
 }
 
-export default AcquisitionResult
+export default memo(AcquisitionResult)

--- a/src/components/ModelSteps/widgets/ConfirmReplaceFile.jsx
+++ b/src/components/ModelSteps/widgets/ConfirmReplaceFile.jsx
@@ -1,0 +1,58 @@
+import React, { memo, useCallback } from 'react'
+import PropTypes from 'prop-types'
+
+import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Button from 'cozy-ui/transpiled/react/Button'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+
+const ConfirmReplaceFile = ({ onReplace, onClose, cozyFilesCount }) => {
+  const { t } = useI18n()
+
+  const onClickReplace = useCallback(
+    isReplaced => () => {
+      onReplace(isReplaced)
+      onClose()
+    },
+    [onClose, onReplace]
+  )
+
+  return (
+    <ConfirmDialog
+      open
+      onClose={onClose}
+      title={t('ConfirmReplaceFile.title', {
+        smart_count: cozyFilesCount
+      })}
+      content={
+        <Typography variant={'body1'}>
+          {t('ConfirmReplaceFile.content', {
+            smart_count: cozyFilesCount
+          })}
+        </Typography>
+      }
+      actions={
+        <>
+          <Button
+            theme="secondary"
+            onClick={onClickReplace(false)}
+            label={t('ConfirmReplaceFile.no')}
+          />
+          <Button
+            theme="danger"
+            onClick={onClickReplace(true)}
+            label={t('ConfirmReplaceFile.yes')}
+          />
+        </>
+      }
+    />
+  )
+}
+
+ConfirmReplaceFile.propTypes = {
+  onReplace: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired,
+  nbOfCozyFiles: PropTypes.number.isRequired
+}
+
+export default memo(ConfirmReplaceFile)

--- a/src/helpers/makeBlobWithCustomAttrs.js
+++ b/src/helpers/makeBlobWithCustomAttrs.js
@@ -1,0 +1,14 @@
+/**
+ * @param {Blob} blobFile
+ * @param {object} attrs - Object with customs attributes
+ * @returns {Blob}
+ */
+export const makeBlobWithCustomAttrs = (blobFile, attrs) => {
+  const newBlob = new Blob([blobFile], { type: blobFile.type })
+
+  for (const [key, value] of Object.entries(attrs)) {
+    newBlob[key] = value
+  }
+
+  return newBlob
+}

--- a/src/helpers/makeBlobWithCustomAttrs.spec.js
+++ b/src/helpers/makeBlobWithCustomAttrs.spec.js
@@ -1,0 +1,21 @@
+import { makeBlobWithCustomAttrs } from 'src/helpers/makeBlobWithCustomAttrs'
+
+describe('makeBlobWithCustomAttrs', () => {
+  const blob = new Blob(['{data: "value"}'], { type: 'application/json' })
+
+  it('should return Blob', () => {
+    const res = makeBlobWithCustomAttrs(blob, {})
+    expect(res.constructor).toEqual(Blob)
+  })
+
+  it('should set the properties provided', () => {
+    const res = makeBlobWithCustomAttrs(blob, { id: '01', name: 'my blob' })
+    expect(res).toHaveProperty('id', '01')
+    expect(res).toHaveProperty('name', 'my blob')
+  })
+
+  it('should return Blob with original type', () => {
+    const res = makeBlobWithCustomAttrs(blob, {})
+    expect(res.type).toEqual('application/json')
+  })
+})

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -47,6 +47,12 @@
     "administrative": "Administrative",
     "papers": "My papers"
   },
+  "ConfirmReplaceFile": {
+    "content": "Would you like to move the file from your Cozy that was used to build this paper to the trash? |||| Would you like to move the files from your Cozy that was used to build this paper to the trash?",
+    "no": "No",
+    "title": "Replace file? |||| Replace files?",
+    "yes": "Yes"
+  },
   "ContactStep": {
     "me": "Me",
     "onLoad": "Document generation",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -47,6 +47,12 @@
     "administrative": "Administratif",
     "papers": "Mes papiers"
   },
+  "ConfirmReplaceFile": {
+    "content": "Souhaitez-vous déplacer dans la corbeille le fichier de votre Cozy ayant servi à construire ce papier ? |||| Souhaitez-vous déplacer dans la corbeille les fichiers de votre Cozy ayant servi à construire ce papier ?",
+    "no": "Non",
+    "title": "Remplacer le fichier ? |||| Remplacer les fichiers ?",
+    "yes": "Oui"
+  },
   "ContactStep": {
     "me": "Moi",
     "onLoad": "Génération du document",


### PR DESCRIPTION
At the end of the process of creating a Paper, if at least one file has been chosen from the Drive, a confirmation modal appears to give the user the choice to replace the original files