### PR TITLE
Fix/stepper modal ux

### DIFF
--- a/src/components/StepperDialog/StepperDialog.jsx
+++ b/src/components/StepperDialog/StepperDialog.jsx
@@ -14,6 +14,7 @@ import MUIDialog, {
 } from 'cozy-ui/transpiled/react/Dialog'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -22,36 +23,57 @@ const useStyles = makeStyles(() => ({
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'center'
+  },
+  typography: {
+    marginTop: isMobile => (!isMobile ? '2px' : '')
   }
 }))
 
-const StepperDialog = ({ onClose, title, content, stepper, ...rest }) => {
-  const classes = useStyles()
-  const { dialogProps, dialogTitleProps, fullScreen, id } = useCozyDialog(rest)
+const StepperDialog = ({
+  onClose,
+  onBack,
+  title,
+  content,
+  stepper,
+  ...rest
+}) => {
+  const { isMobile } = useBreakpoints()
+  const classes = useStyles(isMobile)
+  const { dialogProps, dialogTitleProps, fullScreen } = useCozyDialog(rest)
 
   return (
     <MUIDialog {...dialogProps}>
-      {!fullScreen && onClose && (
-        <DialogCloseButton
-          onClick={onClose}
-          data-test-id={`modal-close-button-${id}`}
-        />
-      )}
+      {!fullScreen && onClose && <DialogCloseButton onClick={onClose} />}
+      {onBack && <DialogBackButton onClick={onBack} />}
       <DialogTitle
         {...dialogTitleProps}
-        className={cx('u-ellipsis', {
-          dialogTitleFull: !onClose,
-          ['u-flex u-flex-justify-between u-flex-items-center u-pl-3']: stepper
+        className={cx('u-ellipsis u-pl-3', {
+          ['u-flex u-flex-justify-between u-flex-items-center']: stepper
         })}
       >
-        <div className={'u-flex'}>
-          {fullScreen && onClose && <DialogBackButton onClick={onClose} />}
-          <Typography variant="h4">{title}</Typography>
-        </div>
-        {stepper && <Typography variant="h6">{stepper}</Typography>}
+        <Typography
+          variant="h4"
+          classes={{ h4: classes.typography }}
+          className={cx({
+            'u-ml-1': !isMobile
+          })}
+        >
+          {title}
+        </Typography>
+        {stepper && (
+          <Typography
+            variant="h6"
+            classes={{ h6: classes.typography }}
+            className={cx({
+              'u-mr-2': !isMobile
+            })}
+          >
+            {stepper}
+          </Typography>
+        )}
       </DialogTitle>
       <Divider />
-      <DialogContent classes={classes}>{content}</DialogContent>
+      <DialogContent classes={{ root: classes.root }}>{content}</DialogContent>
     </MUIDialog>
   )
 }
@@ -59,6 +81,7 @@ const StepperDialog = ({ onClose, title, content, stepper, ...rest }) => {
 StepperDialog.propTypes = {
   open: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
+  onBack: PropTypes.func.isRequired,
   title: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   content: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   size: PropTypes.oneOf(['small', 'medium', 'large'])

--- a/src/components/StepperDialog/StepperDialog.spec.jsx
+++ b/src/components/StepperDialog/StepperDialog.spec.jsx
@@ -1,0 +1,96 @@
+import React from 'react'
+import { fireEvent, render } from '@testing-library/react'
+
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+
+import StepperDialog from 'src/components/StepperDialog/StepperDialog'
+
+/* eslint-disable react/display-name */
+jest.mock('cozy-ui/transpiled/react/hooks/useBreakpoints', () =>
+  jest.fn(() => ({ isMobile: false }))
+)
+
+jest.mock('cozy-ui/transpiled/react/Dialog', () => ({
+  ...jest.requireActual('cozy-ui/transpiled/react/Dialog'),
+  __esModule: true,
+  default: 'MUIDialog'
+}))
+
+jest.mock('cozy-ui/transpiled/react/CozyDialogs', () => ({
+  ...jest.requireActual('cozy-ui/transpiled/react/CozyDialogs'),
+  DialogBackButton: ({ onClick }) => (
+    <div data-testid="DialogBackButton" onClick={onClick} />
+  ),
+  DialogCloseButton: ({ onClick }) => (
+    <div data-testid="DialogCloseButton" onClick={onClick} />
+  )
+}))
+/* eslint-enable react/display-name */
+
+describe('StepperDialog', () => {
+  it('should display "stepper" content', () => {
+    const { getByText } = render(<StepperDialog stepper={'1/2'} />)
+
+    expect(getByText('1/2')).toBeTruthy()
+  })
+
+  describe('DialogCloseButton', () => {
+    const closeAction = jest.fn()
+    it('should render DialogCloseButton in Desktop view & "onClose" prop is defined', () => {
+      useBreakpoints.mockReturnValue({ isMobile: false })
+      const { queryByTestId } = render(<StepperDialog onClose={closeAction} />)
+
+      expect(queryByTestId('DialogCloseButton')).toBeTruthy()
+    })
+
+    it('should not render DialogCloseButton in Desktop view & "onClose" prop is undefined', () => {
+      useBreakpoints.mockReturnValue({ isMobile: false })
+      const { queryByTestId } = render(<StepperDialog />)
+
+      expect(queryByTestId('DialogCloseButton')).not.toBeTruthy()
+    })
+
+    it('should not render DialogCloseButton in Mobile view even if "onClose" prop is defined', () => {
+      useBreakpoints.mockReturnValue({ isMobile: true })
+      const { queryByTestId } = render(<StepperDialog onClose={closeAction} />)
+
+      expect(queryByTestId('DialogCloseButton')).not.toBeTruthy()
+    })
+
+    it('should called closeAction function', () => {
+      useBreakpoints.mockReturnValue({ isMobile: false })
+      const { queryByTestId } = render(<StepperDialog onClose={closeAction} />)
+
+      const dialogCloseButton = queryByTestId('DialogCloseButton')
+
+      fireEvent.click(dialogCloseButton)
+
+      expect(closeAction).toBeCalledTimes(1)
+    })
+  })
+
+  describe('DialogBackButton', () => {
+    const backAction = jest.fn()
+    it('should render DialogBackButton if "onBack" prop is defined', () => {
+      const { queryByTestId } = render(<StepperDialog onBack={backAction} />)
+
+      expect(queryByTestId('DialogBackButton')).toBeTruthy()
+    })
+
+    it('should not render DialogBackButton if "onBack" prop is undefined', () => {
+      const { queryByTestId } = render(<StepperDialog />)
+
+      expect(queryByTestId('DialogBackButton')).not.toBeTruthy()
+    })
+
+    it('should called backAction function', () => {
+      const { queryByTestId } = render(<StepperDialog onBack={backAction} />)
+
+      const dialogBackButton = queryByTestId('DialogBackButton')
+
+      fireEvent.click(dialogBackButton)
+
+      expect(backAction).toBeCalledTimes(1)
+    })
+  })
+})

--- a/src/components/StepperDialog/StepperDialogWrapper.jsx
+++ b/src/components/StepperDialog/StepperDialogWrapper.jsx
@@ -11,13 +11,15 @@ const StepperDialogWrapper = () => {
     allCurrentSteps,
     currentStepIndex,
     previousStep,
-    stepperDialogTitle
+    stepperDialogTitle,
+    setIsStepperDialogOpen
   } = useStepperDialog()
 
   return (
     <StepperDialog
       open
-      onClose={previousStep}
+      onClose={() => setIsStepperDialogOpen(false)}
+      onBack={previousStep}
       title={scannerT(`items.${stepperDialogTitle}`)}
       content={<StepperDialogContent />}
       stepper={`${currentStepIndex}/${allCurrentSteps.length}`}


### PR DESCRIPTION
Cette PR fixe quelques retours client sur la StepperDialog en mode Desktop :
- La croix pour fermer en haut à droite se comportait comme un retour arrière. :upside_down_face:
- Le stepper était masqué derrière cette dernière.
- Il n'y avait pas de flèche pour revenir en arrière.