### PR TITLE
fix: Change prop Icon by startIcon on new Buttons

### DIFF
--- a/src/components/ModelSteps/ScanDesktopActions.jsx
+++ b/src/components/ModelSteps/ScanDesktopActions.jsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import FileInput from 'cozy-ui/transpiled/react/FileInput'
+import Icon from 'cozy-ui/transpiled/react/Icon'
 import FolderMoveto from 'cozy-ui/transpiled/react/Icons/FolderMoveto'
 import PhoneUpload from 'cozy-ui/transpiled/react/Icons/PhoneUpload'
 
@@ -17,7 +18,7 @@ const ScanDesktopActions = ({ openFilePickerModal, onChangeFile }) => {
         variant="secondary"
         style={styleBtn}
         onClick={openFilePickerModal}
-        icon={FolderMoveto}
+        startIcon={<Icon icon={FolderMoveto} />}
         label={t('Scan.selectPicFromCozy')}
         data-testid="selectPicFromCozy-btn"
       />
@@ -29,7 +30,7 @@ const ScanDesktopActions = ({ openFilePickerModal, onChangeFile }) => {
         data-testid="importPicFromDesktop-btn"
       >
         <Button
-          icon={PhoneUpload}
+          startIcon={<Icon icon={PhoneUpload} />}
           component={'a'}
           className={'u-w-100 u-m-0 u-mb-1'}
           label={t('Scan.importPicFromDesktop')}

--- a/src/components/ModelSteps/ScanMobileActions.jsx
+++ b/src/components/ModelSteps/ScanMobileActions.jsx
@@ -4,6 +4,7 @@ import Button from 'cozy-ui/transpiled/react/Buttons'
 import Camera from 'cozy-ui/transpiled/react/Icons/Camera'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import FileInput from 'cozy-ui/transpiled/react/FileInput'
+import Icon from 'cozy-ui/transpiled/react/Icon'
 import FolderMoveto from 'cozy-ui/transpiled/react/Icons/FolderMoveto'
 import PhoneUpload from 'cozy-ui/transpiled/react/Icons/PhoneUpload'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
@@ -23,7 +24,7 @@ const ScanMobileActions = ({ openFilePickerModal, onChangeFile }) => {
           variant="secondary"
           style={styleBtn}
           onClick={openFilePickerModal}
-          icon={FolderMoveto}
+          startIcon={<Icon icon={FolderMoveto} />}
           label={t('Scan.selectPicFromCozy')}
           data-testid="selectPicFromCozy-btn"
         />
@@ -38,7 +39,7 @@ const ScanMobileActions = ({ openFilePickerModal, onChangeFile }) => {
             variant={'secondary'}
             component={'a'}
             style={styleBtn}
-            icon={PhoneUpload}
+            startIcon={<Icon icon={PhoneUpload} />}
             fullWidth
             className={'u-m-0'}
             label={t('Scan.importPicFromMobile')}
@@ -54,7 +55,7 @@ const ScanMobileActions = ({ openFilePickerModal, onChangeFile }) => {
         data-testid="takePic-btn"
       >
         <Button
-          icon={Camera}
+          startIcon={<Icon icon={Camera} />}
           component={'a'}
           fullWidth
           className={'u-m-0'}


### PR DESCRIPTION
Following the PR #176, the prop `icon` on the Buttons has changed for `startIcon` which takes a component `Icon`.