### PR TITLE
chore(deps): Configure renovate to open PR directly on cozy libraries

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,33 @@
 {
   "extends": [
-    "cozy"
-  ]
+    "config:base",
+    ":semanticCommitTypeAll(fix)"
+  ],
+  "rangeStrategy": "pin",
+  "packageRules": [
+    {
+      "excludePackagePrefixes": [
+        "cozy-"
+      ],
+      "extends": [
+        "schedule:monthly"
+      ],
+      "prHourlyLimit": 1
+    },
+    {
+      "matchPackagePrefixes": [
+        "cozy-"
+      ],
+      "extends": [
+        ":disableDependencyDashboard"
+      ],
+      "schedule": "at any time",
+      "prHourlyLimit": 0
+    }
+  ],
+  "timezone": "Europe/Paris",
+  "addLabels": [
+    "dependencies"
+  ],
+  "updateNotScheduled": false
 }


### PR DESCRIPTION
 and keep using "Dependency Dashboard" on every deps except cozy-*.

 since renovate@26.0.0, the "Dependency Dashboard" is listing issues to upgrade, instead of opening PRs.

For Cozy libraries, we want the creation of PR immediately.


