### PR TITLE
Feat/update cozy mespapiers lib to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 0.6.0
 
+## ✨ Features
+
+* Update cozy-mespapiers-lib from [0.42.1](https://github.com/cozy/cozy-libs/releases/tag/cozy-mespapiers-lib%400.42.1) to [1.1.0](https://github.com/cozy/cozy-libs/releases/tag/cozy-mespapiers-lib%401.1.0)
+
 # 0.5.0
 
 ## 📦 Library updates

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "cozy-flags": "^2.9.0",
     "cozy-harvest-lib": "^9.10.1",
     "cozy-intent": "^1.17.3",
-    "cozy-mespapiers-lib": "0.42.3",
+    "cozy-mespapiers-lib": "^1.1.0",
     "cozy-realtime": "4.2.1",
     "cozy-scripts": "^6.3.5",
     "cozy-sharing": "4.3.1",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -11,17 +11,12 @@ import Typography from 'cozy-ui/transpiled/react/Typography'
 import { Layout, Main, Content } from 'cozy-ui/transpiled/react/Layout'
 import IconSprite from 'cozy-ui/transpiled/react/Icon/Sprite'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
-import MesPapiers, { PapersFab } from 'cozy-mespapiers-lib'
+import MesPapiers from 'cozy-mespapiers-lib'
 
 const PaperView = props => {
   const { lang } = useI18n()
 
-  return (
-    <>
-      <MesPapiers {...props} lang={lang} />
-      <PapersFab />
-    </>
-  )
+  return <MesPapiers {...props} lang={lang} />
 }
 
 const AppRouter = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4947,10 +4947,10 @@ cozy-logger@^1.9.0:
     chalk "^2.4.2"
     json-stringify-safe "5.0.1"
 
-cozy-mespapiers-lib@0.42.3:
-  version "0.42.3"
-  resolved "https://registry.yarnpkg.com/cozy-mespapiers-lib/-/cozy-mespapiers-lib-0.42.3.tgz#a71689311206a97dda327f71ede841bae8725404"
-  integrity sha512-IBprt5N6FC6vqJaq5uVAiXUApEuobbED/fxhYY07Qvj9PnroaanLtZco4GcBdfVEYrF9H5cWOgRxDuWRAUpGtQ==
+cozy-mespapiers-lib@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-mespapiers-lib/-/cozy-mespapiers-lib-1.1.0.tgz#7ff983b28fe9597d514a7f3beeb56814150d4acd"
+  integrity sha512-iNpwYdqG2HIlogikMIGRvEPLyX1FYd92vTzKgiZg5nxzuA2xl+yaN1z2rkB49ZVYG/ghl/228QS4CqytJdIpUA==
   dependencies:
     "@date-io/date-fns" "1"
     "@material-ui/core" "4.12.3"


### PR DESCRIPTION
L'implémentation du composant PaperFab à changé sur la version [0.44.0](https://github.com/cozy/cozy-libs/releases/tag/cozy-mespapiers-lib%400.44.0).
Il n'est plus exporté et est utilisé par défaut dans la lib.