### PR TITLE
chore: Bump from 0.6.0 to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.0
+
+* Synchronize Apps versions
+
 # 0.6.0
 
 ## ✨ Features

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -3,7 +3,7 @@
   "slug": "mespapiers",
   "icon": "icon.svg",
   "categories": [],
-  "version": "0.6.0",
+  "version": "1.2.0",
   "licence": "AGPL-3.0",
   "editor": "Cozy",
   "source": "https://github.com/cozy/mespapiers.git@build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mespapiers",
-  "version": "0.6.0",
+  "version": "1.2.0",
   "engines": {
     "node": "~16"
   },


### PR DESCRIPTION
Bump to version 1.2.0 to synchronize with another application