### PR TITLE
Create expiration service

### DIFF
--- a/.bundlemonrc
+++ b/.bundlemonrc
@@ -22,8 +22,7 @@
     ],
     "groups": [
         {
-            "path": "**/*.js",
-            "maxPercentIncrease": 5
+            "path": "**/*.js"
         },
         {
             "path": "**/*.css"

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ $ yarn start
 ```
 
 ```sh
-# in an other terminal, run the docker image 
+# in an other terminal, run the docker image
 $ cd mespapiers
 $ yarn stack:docker:dev
-``` 
+```
 
 After the build and the docker image launched, your app is now available at http://mespapiers.cozy.tools:8080.
 
@@ -83,8 +83,34 @@ $ yarn test
 
 :pushpin: Don't forget to update / create new tests when you contribute to code to keep the app the consistent.
 
+___
+# Services
 
-## Models
+## expiration:
+  This service consists in checking every day between 1pm & 3pm if qualified documents are about to expire <br/>(_expiry date_ - _offset of document type_)
+
+## Developing
+In prod env, triggers are created during the installation of the app. In local env, triggers must be created & launched manually:
+
+To execute the trigger in local development, follow this steps:
+- You will need to define 2 environment variables:
+  ```
+  $ export COZY_URL='http://cozy.localhost:8080'
+  $ export COZY_CREDENTIALS=$(cozy-stack instances token-app cozy.localhost:8080 mespapiers)
+  ```
+
+- Launch once the trigger manually (create upstream if needed)
+  ```
+  yarn triggers:launch
+  ```
+
+- Launch the service manually as much as necessary
+  ```
+  yarn service
+  ```
+
+___
+# Models
 
 The Cozy datastore stores documents, which can be seen as JSON objects. A `doctype` is simply a declaration of the fields in a given JSON object, to store similar objects in an homogeneous fashion.
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "enzyme-adapter-react-16": "1.15.6",
     "eslint-config-cozy-app": "^4.0.0",
     "git-directory-deploy": "1.5.1",
+    "mockdate": "3.0.5",
     "react-test-renderer": "16.14.0",
     "redux-mock-store": "1.5.4",
     "stylint": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "test": "cs test --verbose --coverage",
     "cozyPublish": "cozy-app-publish --token $REGISTRY_TOKEN --prepublish downcloud --postpublish mattermost --space mespapiers",
     "stack:docker:dev": "cs stackDocker",
-    "stack:docker:prod": "cs stackDocker --prod"
+    "stack:docker:prod": "cs stackDocker --prod",
+    "service": "node build/services/expiration/mespapiers.js",
+    "triggers:launch": "node build/services/launchTriggers/mespapiers.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "cozy-scripts": "6.3.0",
     "cozy-sharing": "4.3.1",
     "cozy-ui": "^77.2.0",
+    "date-fns": "2.29.3",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-router-dom": "6.3.0"

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,8 @@
+export const CONTACTS_DOCTYPE = 'io.cozy.contacts'
+export const FILES_DOCTYPE = 'io.cozy.files'
+export const TRIGGERS_DOCTYPE = 'io.cozy.triggers'
+
+export const APP_SLUG = 'mespapiers'
+export const EXPIRATION_SERVICE_NAME = 'expiration'
+export const DEFAULT_NOTICE_PERIOD_DAYS = 90
+export const PERSONAL_SPORTING_LICENCE_NOTICE_PERIOD_DAYS = 15

--- a/src/doctypes/index.js
+++ b/src/doctypes/index.js
@@ -1,8 +1,4 @@
-export const APPS_DOCTYPE = 'io.cozy.apps'
-export const CONTACTS_DOCTYPE = 'io.cozy.contacts'
-export const FILES_DOCTYPE = 'io.cozy.files'
-export const PERMISSIONS_DOCTYPE = 'io.cozy.permissions'
-export const SETTINGS_DOCTYPE = 'io.cozy.mespapiers.settings'
+import { CONTACTS_DOCTYPE, FILES_DOCTYPE } from 'src/constants'
 
 // the documents schema, necessary for CozyClient
 export default {

--- a/src/helpers/queries.js
+++ b/src/helpers/queries.js
@@ -1,0 +1,48 @@
+import { Q } from 'cozy-client'
+
+import { FILES_DOCTYPE, TRIGGERS_DOCTYPE } from 'src/constants'
+
+export const buildTriggerByIdQuery = triggerId => {
+  return {
+    definition: Q(TRIGGERS_DOCTYPE).getById(triggerId)
+  }
+}
+
+export const buildTriggerByServiceNameQuery = serviceName => {
+  return {
+    definition: Q(TRIGGERS_DOCTYPE)
+      .where({
+        'message.name': serviceName
+      })
+      .indexFields(['message.name'])
+  }
+}
+
+export const buildAllFilesToNotifyQuery = () => {
+  return {
+    definition: Q(FILES_DOCTYPE)
+      .partialIndex({
+        type: 'file',
+        trashed: false,
+        'metadata.qualification.label': {
+          $exists: true
+        },
+        'metadata.notifiedAt': {
+          $exists: false
+        }
+      })
+      .indexFields(['metadata.qualification.label'])
+      .select([
+        'name',
+        'metadata',
+        'metadata.qualification.label',
+        'metadata.notifiedAt',
+        'referenced_by',
+        'created_at',
+        'updated_at',
+        'type',
+        'trashed'
+      ])
+      .limitBy(1000)
+  }
+}

--- a/src/helpers/service.js
+++ b/src/helpers/service.js
@@ -1,0 +1,167 @@
+import sub from 'date-fns/sub'
+import add from 'date-fns/add'
+
+import log from 'cozy-logger'
+import papersDefinitions from 'cozy-mespapiers-lib/dist/constants/papersDefinitions.json'
+
+import {
+  APP_SLUG,
+  DEFAULT_NOTICE_PERIOD_DAYS,
+  PERSONAL_SPORTING_LICENCE_NOTICE_PERIOD_DAYS,
+  TRIGGERS_DOCTYPE
+} from 'src/constants'
+import {
+  buildAllFilesToNotifyQuery,
+  buildTriggerByIdQuery,
+  buildTriggerByServiceNameQuery
+} from 'src/helpers/queries'
+
+/**
+ * @param {CozyClient} client - Instance of CozyClient
+ * @param {string} serviceName - Name of the service
+ * @returns {Promise<Object>} Normalized trigger
+ */
+export const createTriggerByName = async (client, serviceName) => {
+  log('info', `Create trigger with "${serviceName}" service name`)
+  if (!serviceName) {
+    throw new Error('Invalid service name')
+  }
+
+  const attrs = {
+    _type: TRIGGERS_DOCTYPE,
+    type: '@daily',
+    arguments: 'between 1pm and 3pm',
+    worker: 'service',
+    message: {
+      name: serviceName,
+      slug: APP_SLUG
+    }
+  }
+
+  return client.save(attrs)
+}
+
+/**
+ * @param {CozyClient} client - Instance of CozyClient
+ * @param {string} serviceName - Name of the service
+ * @returns {Promise<Object>} Normalized trigger
+ */
+export const fetchOrCreateTriggerByName = async (client, serviceName) => {
+  log('info', `Fetch trigger with "${serviceName}" service name`)
+
+  const triggerByServiceNameQuery = buildTriggerByServiceNameQuery(serviceName)
+  const { data: triggers } = await client.query(
+    triggerByServiceNameQuery.definition
+  )
+
+  if (!triggers || triggers.length === 0) {
+    log('error', `Can't find trigger with "${serviceName}" service name`)
+    return createTriggerByName(client, serviceName)
+  }
+
+  const triggerByIdQuery = buildTriggerByIdQuery(triggers[0].id)
+  return client.query(triggerByIdQuery.definition)
+}
+
+/**
+ * @param {IOCozyFile} file - An CozyFile
+ * @param {string} dateLabel - Label of date
+ * @returns {Date} Normalize expiration date
+ */
+export const computeNormalizeExpirationDate = (file, dateLabel) => {
+  if (file.metadata[dateLabel]) {
+    if (dateLabel === 'referencedDate') {
+      return add(new Date(file.metadata[dateLabel] ?? file.created_at), {
+        days: 365
+      })
+    }
+    return new Date(file.metadata[dateLabel])
+  }
+
+  return null
+}
+
+/**
+ * @param {IOCozyFile} file - An CozyFile
+ * @param {string} dateLabel - Label of date
+ * @returns {Date} Notice date
+ */
+export const computeNoticeDate = (file, dateLabel) => {
+  let noticeDays
+  if (file.metadata[dateLabel]) {
+    if (dateLabel === 'referencedDate') {
+      noticeDays = PERSONAL_SPORTING_LICENCE_NOTICE_PERIOD_DAYS
+    }
+    if (dateLabel === 'expirationDate') {
+      noticeDays =
+        parseInt(file.metadata.noticePeriod, 10) || DEFAULT_NOTICE_PERIOD_DAYS
+    }
+  }
+  if (!noticeDays) {
+    return null
+  }
+
+  const normalizeExpirationDate = computeNormalizeExpirationDate(
+    file,
+    dateLabel
+  )
+  return normalizeExpirationDate
+    ? sub(normalizeExpirationDate, {
+        days: noticeDays
+      })
+    : null
+}
+
+/**
+ * @param {IOCozyFile} file - An CozyFile
+ * @returns {{ label: string, country?: string, expirationDateAttribute: string }[]} papersToNotify - Rule in the paperDefinitions file
+ */
+const getPaperToNotify = file => {
+  const { papersToNotify } = papersDefinitions.notifications
+
+  return papersToNotify.find(({ label, expirationDateAttribute, country }) => {
+    let validCountry = true
+    if (country && country !== 'fr') {
+      validCountry = file.metadata.country === country
+    }
+
+    return (
+      validCountry &&
+      label === file.metadata.qualification.label &&
+      file.metadata[expirationDateAttribute]
+    )
+  })
+}
+
+/**
+ * @param {IOCozyFile[]} files - List of CozyFile
+ * @returns {IOCozyFile[]} List of CozyFile that must be notified
+ */
+export const getfilesNeedNotified = files => {
+  return files.filter(file => {
+    const paperToNotify = getPaperToNotify(file)
+
+    if (paperToNotify) {
+      const noticeDate = computeNoticeDate(
+        file,
+        paperToNotify.expirationDateAttribute
+      )
+      return noticeDate ? new Date() >= noticeDate : false
+    }
+
+    return false
+  })
+}
+
+/**
+ * @param {CozyClient} client - Instance of CozyClient
+ * @returns {Promise<IOCozyFile[]>} List of CozyFile that must be notified
+ */
+export const fetchAllfilesToNotify = async client => {
+  log('info', `Fetch all files to notify`)
+
+  const filesToNotifyQuery = buildAllFilesToNotifyQuery()
+  const files = await client.queryAll(filesToNotifyQuery.definition)
+
+  return getfilesNeedNotified(files)
+}

--- a/src/helpers/service.spec.js
+++ b/src/helpers/service.spec.js
@@ -1,0 +1,110 @@
+import MockDate from 'mockdate'
+
+import {
+  computeNormalizeExpirationDate,
+  computeNoticeDate,
+  getfilesNeedNotified
+} from 'src/helpers/service'
+
+jest.mock('cozy-mespapiers-lib/dist/constants/papersDefinitions.json', () => ({
+  notifications: {
+    papersToNotify: [
+      {
+        label: 'national_id_card',
+        country: 'fr',
+        expirationDateAttribute: 'expirationDate'
+      },
+      {
+        label: 'residence_permit',
+        expirationDateAttribute: 'expirationDate'
+      },
+      {
+        label: 'personal_sporting_licence',
+        expirationDateAttribute: 'referencedDate'
+      }
+    ]
+  }
+}))
+
+describe('Service', () => {
+  beforeEach(() => {
+    MockDate.set('2022-11-01T11:35:58.118Z')
+  })
+  afterEach(() => {
+    MockDate.reset()
+  })
+
+  const fakeFile01 = {
+    _id: '01',
+    name: 'national id card',
+    created_at: '2022-09-01T00:00:00.000Z',
+    metadata: {
+      qualification: { label: 'national_id_card' },
+      expirationDate: '2022-09-23T11:35:58.118Z'
+    }
+  }
+  const fakeFile02 = {
+    _id: '02',
+    name: 'personal sporting licence',
+    created_at: '2022-09-01T00:00:00.000Z',
+    metadata: {
+      qualification: { label: 'personal_sporting_licence' },
+      referencedDate: '2022-09-23T11:35:58.118Z'
+    }
+  }
+
+  describe('computeExpirationDate', () => {
+    it('should return expirationDate', () => {
+      const res = computeNormalizeExpirationDate(fakeFile01, 'expirationDate')
+
+      expect(res.toISOString()).toBe('2022-09-23T11:35:58.118Z')
+    })
+    it('should return referencedDate plus 365 days', () => {
+      const res = computeNormalizeExpirationDate(fakeFile02, 'referencedDate')
+
+      expect(res.toISOString()).toBe('2023-09-23T11:35:58.118Z')
+    })
+
+    it('should return "null" if metadata is not found', () => {
+      const res = computeNormalizeExpirationDate(fakeFile02, 'expirationDate')
+
+      expect(res).toBeNull()
+    })
+  })
+
+  describe('computeNoticeDate', () => {
+    it('should return notice date for file with expirationDate metadata', () => {
+      const res = computeNoticeDate(fakeFile01, 'expirationDate')
+
+      expect(res.toISOString()).toBe('2022-06-25T11:35:58.118Z')
+    })
+    it('should return notice date for file with referencedDate metadata', () => {
+      const res = computeNoticeDate(fakeFile02, 'referencedDate')
+
+      expect(res.toISOString()).toBe('2023-09-08T11:35:58.118Z')
+    })
+    it('should return null for file without corresponding metadata', () => {
+      const res = computeNoticeDate(fakeFile02, 'expirationDate')
+
+      expect(res).toBeNull()
+    })
+  })
+
+  describe('getfilesNeedNotified', () => {
+    it('should return only files that need to be notified', () => {
+      const res = getfilesNeedNotified([fakeFile01, fakeFile02])
+
+      expect(res).toEqual([
+        {
+          _id: '01',
+          created_at: '2022-09-01T00:00:00.000Z',
+          metadata: {
+            expirationDate: '2022-09-23T11:35:58.118Z',
+            qualification: { label: 'national_id_card' }
+          },
+          name: 'national id card'
+        }
+      ])
+    })
+  })
+})

--- a/src/targets/services/expiration.js
+++ b/src/targets/services/expiration.js
@@ -1,0 +1,23 @@
+import fetch from 'node-fetch'
+
+import CozyClient from 'cozy-client'
+import log from 'cozy-logger'
+
+import schema from 'src/doctypes'
+import { fetchAllfilesToNotify } from 'src/helpers/service'
+import { EXPIRATION_SERVICE_NAME } from 'src/constants'
+
+global.fetch = fetch
+
+const expiration = async () => {
+  log('info', `Start ${EXPIRATION_SERVICE_NAME} service`)
+  const client = CozyClient.fromEnv(process.env, { schema })
+
+  const files = await fetchAllfilesToNotify(client)
+  log('info', `Found ${files.length} file(s)`)
+}
+
+expiration().catch(error => {
+  log('critical', error)
+  process.exit(1)
+})

--- a/src/targets/services/launchTriggers.js
+++ b/src/targets/services/launchTriggers.js
@@ -1,0 +1,62 @@
+import fetch from 'node-fetch'
+
+import CozyClient from 'cozy-client'
+import log from 'cozy-logger'
+
+import { EXPIRATION_SERVICE_NAME, TRIGGERS_DOCTYPE } from 'src/constants'
+import { fetchOrCreateTriggerByName } from 'src/helpers/service'
+import schema from 'src/doctypes'
+
+global.fetch = fetch
+
+const triggersName = [EXPIRATION_SERVICE_NAME]
+
+/**
+ * @param {CozyClient} client - Instance of CozyClient
+ * @param {string} serviceName - Name of service
+ * @returns
+ */
+const fetchAndLaunchTrigger = async (client, serviceName) => {
+  const { data: normalizedTrigger } = await fetchOrCreateTriggerByName(
+    client,
+    serviceName
+  )
+
+  log('info', `Launch trigger with ${serviceName} service name`)
+  await client.collection(TRIGGERS_DOCTYPE).launch(normalizedTrigger)
+
+  return serviceName
+}
+
+/**
+ * Launch manually (& create if necessary) triggers
+ * For development usage, see documentation for more details
+ */
+const launchTriggers = async () => {
+  try {
+    log('info', `Start launchTriggers`)
+
+    const client = CozyClient.fromEnv(process.env, { schema })
+
+    const result = await Promise.allSettled(
+      triggersName.map(triggerName =>
+        fetchAndLaunchTrigger(client, triggerName)
+      )
+    )
+    for (const res of result) {
+      const { status, value, reason } = res
+
+      if (status === 'rejected') {
+        log('critical', reason)
+      }
+      if (status === 'fulfilled') {
+        log('info', `Launch trigger ${value} success`)
+      }
+    }
+  } catch (error) {
+    log('critical', error)
+    process.exit(1)
+  }
+}
+
+launchTriggers()

--- a/yarn.lock
+++ b/yarn.lock
@@ -5437,6 +5437,11 @@ date-fns@2.23.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.23.0.tgz#4e886c941659af0cf7b30fafdd1eaa37e88788a9"
   integrity sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==
 
+date-fns@2.29.3:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
+
 date-fns@^1.28.5, date-fns@^1.30.1:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9904,6 +9904,11 @@ mkdirp@0.x.x, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1, mkdirp
   dependencies:
     minimist "^1.2.5"
 
+mockdate@3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.5.tgz#789be686deb3149e7df2b663d2bc4392bc3284fb"
+  integrity sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==
+
 mout@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/mout/-/mout-0.5.0.tgz#ff967566a90f29595e9cb8b6e7800a5b56635583"


### PR DESCRIPTION
Cette PR se contente d'implémenter le service qui doit retourner les fichiers(papiers) qui vont expirer.

### Pour un document avec une date d'expiration :
- Carte d'identité FR
- Titres de séjours

On se base sur la date d'expiration(expirationDate) - 90 jours (90 est la valeur par défaut, l'utilisateur aura le choix lors de la création ou édition du papier)

### Pour un document sans date d'expiration :
- Licence sportive

Dans ce cas, on se base sur la date de référence(referencedDate) + 365, avec un délai de prévenance de - 15 jours. 
Si la date de référence n'est pas renseigné, on se base alors sur la date de création(created_at) du fichier.

```
### 🔧 Tech

* Add expiration service
```
