### PR TITLE
Put expiration service on top of cozy client helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "stylint": "2.0.0"
   },
   "dependencies": {
-    "cozy-client": "^34.2.0",
+    "cozy-client": "^34.4.0",
     "cozy-device-helper": "2.2.1",
     "cozy-doctypes": "^1.83.8",
     "cozy-flags": "^2.9.0",

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,7 +4,5 @@ export const TRIGGERS_DOCTYPE = 'io.cozy.triggers'
 
 export const APP_SLUG = 'mespapiers'
 export const EXPIRATION_SERVICE_NAME = 'expiration'
-export const DEFAULT_NOTICE_PERIOD_DAYS = 90
-export const PERSONAL_SPORTING_LICENCE_NOTICE_PERIOD_DAYS = 15
 export const lang = process.env.COZY_LOCALE || 'fr'
 export const dictRequire = lang => require(`locales/${lang}`)

--- a/src/helpers/service.spec.js
+++ b/src/helpers/service.spec.js
@@ -1,30 +1,6 @@
 import MockDate from 'mockdate'
 
-import {
-  computeNormalizeExpirationDate,
-  computeNoticeDate,
-  getfilesNeedNotified
-} from 'src/helpers/service'
-
-jest.mock('cozy-mespapiers-lib/dist/constants/papersDefinitions.json', () => ({
-  notifications: {
-    papersToNotify: [
-      {
-        label: 'national_id_card',
-        country: 'fr',
-        expirationDateAttribute: 'expirationDate'
-      },
-      {
-        label: 'residence_permit',
-        expirationDateAttribute: 'expirationDate'
-      },
-      {
-        label: 'personal_sporting_licence',
-        expirationDateAttribute: 'referencedDate'
-      }
-    ]
-  }
-}))
+import { getfilesNeedNotified } from 'src/helpers/service'
 
 describe('Service', () => {
   beforeEach(() => {
@@ -58,43 +34,6 @@ describe('Service', () => {
     name: 'unknown',
     created_at: '2022-09-01T00:00:00.000Z'
   }
-
-  describe('computeExpirationDate', () => {
-    it('should return expirationDate', () => {
-      const res = computeNormalizeExpirationDate(fakeFile01, 'expirationDate')
-
-      expect(res).toBe('2022-09-23T11:35:58.118Z')
-    })
-    it('should return referencedDate plus 365 days', () => {
-      const res = computeNormalizeExpirationDate(fakeFile02, 'referencedDate')
-
-      expect(res).toBe('2022-09-23T11:35:58.118Z')
-    })
-
-    it('should return "null" if metadata is not found', () => {
-      const res = computeNormalizeExpirationDate(fakeFile02, 'expirationDate')
-
-      expect(res).toBeNull()
-    })
-  })
-
-  describe('computeNoticeDate', () => {
-    it('should return notice date for file with expirationDate metadata', () => {
-      const res = computeNoticeDate(fakeFile01, 'expirationDate')
-
-      expect(res).toBe('2022-06-25T11:35:58.118Z')
-    })
-    it('should return notice date for file with referencedDate metadata', () => {
-      const res = computeNoticeDate(fakeFile02, 'referencedDate')
-
-      expect(res).toBe('2022-09-08T11:35:58.118Z')
-    })
-    it('should return null for file without corresponding metadata', () => {
-      const res = computeNoticeDate(fakeFile02, 'expirationDate')
-
-      expect(res).toBeNull()
-    })
-  })
 
   describe('getfilesNeedNotified', () => {
     it('should return only files that need to be notified', () => {

--- a/src/helpers/service.spec.js
+++ b/src/helpers/service.spec.js
@@ -40,7 +40,8 @@ describe('Service', () => {
     created_at: '2022-09-01T00:00:00.000Z',
     metadata: {
       qualification: { label: 'national_id_card' },
-      expirationDate: '2022-09-23T11:35:58.118Z'
+      expirationDate: '2022-09-23T11:35:58.118Z',
+      noticePeriod: '90'
     }
   }
   const fakeFile02 = {
@@ -51,6 +52,11 @@ describe('Service', () => {
       qualification: { label: 'personal_sporting_licence' },
       referencedDate: '2021-09-23T11:35:58.118Z'
     }
+  }
+  const fakeFile03 = {
+    _id: '03',
+    name: 'unknown',
+    created_at: '2022-09-01T00:00:00.000Z'
   }
 
   describe('computeExpirationDate', () => {
@@ -92,25 +98,24 @@ describe('Service', () => {
 
   describe('getfilesNeedNotified', () => {
     it('should return only files that need to be notified', () => {
-      const res = getfilesNeedNotified([fakeFile01, fakeFile02])
+      const res = getfilesNeedNotified([fakeFile01, fakeFile02, fakeFile03])
 
       expect(res).toEqual([
         {
           expirationDate: '2022-09-23T11:35:58.118Z',
-          noticeDate: '2022-06-25T11:35:58.118Z',
           file: {
             _id: '01',
             created_at: '2022-09-01T00:00:00.000Z',
             metadata: {
+              qualification: { label: 'national_id_card' },
               expirationDate: '2022-09-23T11:35:58.118Z',
-              qualification: { label: 'national_id_card' }
+              noticePeriod: '90'
             },
             name: 'national id card'
           }
         },
         {
           expirationDate: '2022-09-23T11:35:58.118Z',
-          noticeDate: '2022-09-08T11:35:58.118Z',
           file: {
             _id: '02',
             name: 'personal sporting licence',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4972,16 +4972,17 @@ cozy-client@13.8.3:
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
 
-cozy-client@^34.2.0:
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-34.2.0.tgz#d5af57b638b46dc640653e4bc603534353239632"
-  integrity sha512-t4YYXuGlrStQPEmReJm6nrrVWeKh4Jxrwuh4XSEuHCApH775wPGZZfDs1RdtYx/wCFPfI5PVM0BmvCosGju/bw==
+cozy-client@^34.4.0:
+  version "34.4.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-34.4.0.tgz#7d72aa3a38c08de4f3597c5fc68998553dd29f2f"
+  integrity sha512-Vh50SGKVHaxT1pDlmXn5AtEd8W2dzPFczXLOm4A9HuBttNUzS8cT2/MXfo9Xs7YV7nU/PhPlKtyvdrZqo9RxXQ==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
     cozy-stack-client "^34.1.5"
+    date-fns "2.29.3"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
     microee "^0.0.6"


### PR DESCRIPTION
~~This is the last PR of the series that aims to add expiration information to the viewer and paper items.~~
This will be on top of https://github.com/cozy/cozy-client/pull/1274 and thus will need an update of `cozy-client`.
This does not include the work made in https://github.com/cozy/cozy-ui/pull/2294 and https://github.com/cozy/cozy-libs/pull/1894 that will also require an update of `cozy-ui` and `cozy-mespapiers-lib`.

```
### ✨ Features

* Update cozy-client from [34.2.0](https://github.com/cozy/cozy-client/releases/tag/v34.2.0) to [34.4.0](https://github.com/cozy/cozy-client/releases/tag/v34.4.0)

```