### PR TITLE
Fix email wording

### DIFF
--- a/src/notifications/index.js
+++ b/src/notifications/index.js
@@ -1,9 +1,14 @@
 import format from 'date-fns/format'
 
-import { generateWebLink } from 'cozy-client'
+import { generateWebLink, models } from 'cozy-client'
 import { NotificationView } from 'cozy-notifications'
 
 import template from 'raw-loader!./template.hbs'
+import { APP_SLUG } from 'src/constants'
+
+const {
+  file: { splitFilename }
+} = models
 
 /**
  * @typedef {object} FilesInfo
@@ -65,8 +70,9 @@ class ExpirationNotification extends NotificationView {
       date: format(new Date(), 'dd/MM/yyyy'),
       filesInfo: this.filesInfo.map(fileInfo => {
         const { file, expirationDate } = fileInfo
+        const { filename } = splitFilename(file)
         const paperLink = generateWebLink({
-          slug: 'mespapiers',
+          slug: APP_SLUG,
           cozyUrl: this.client.getStackClient().uri,
           subDomainType: 'nested',
           pathname: '/',
@@ -74,14 +80,14 @@ class ExpirationNotification extends NotificationView {
         })
 
         return {
-          name: file.name,
+          name: filename,
           paperLink,
           expirationDate
         }
       }),
       homeUrl: this.client.getStackClient().uri,
       mespapiersUrl: generateWebLink({
-        slug: 'mespapiers',
+        slug: APP_SLUG,
         cozyUrl: this.client.getStackClient().uri,
         subDomainType: 'nested',
         pathname: '/',

--- a/src/notifications/index.js
+++ b/src/notifications/index.js
@@ -74,7 +74,7 @@ class ExpirationNotification extends NotificationView {
         const paperLink = generateWebLink({
           slug: APP_SLUG,
           cozyUrl: this.client.getStackClient().uri,
-          subDomainType: 'nested',
+          subDomainType: this.client.getInstanceOptions().subdomain,
           pathname: '/',
           hash: `paper/file/${file.metadata.qualification.label}/${file._id}`
         })
@@ -89,14 +89,14 @@ class ExpirationNotification extends NotificationView {
       mespapiersUrl: generateWebLink({
         slug: APP_SLUG,
         cozyUrl: this.client.getStackClient().uri,
-        subDomainType: 'nested',
+        subDomainType: this.client.getInstanceOptions().subdomain,
         pathname: '/',
         hash: 'paper'
       }),
       settingsUrl: generateWebLink({
         slug: 'settings',
         cozyUrl: this.client.getStackClient().uri,
-        subDomainType: 'nested',
+        subDomainType: this.client.getInstanceOptions().subdomain,
         pathname: '/'
       })
     }


### PR DESCRIPTION
```
### 🐛 Bug Fixes

* Display filename without extension in the notification email
* Get the subDomain from the client instance
```
