### PR TITLE
Update `cozy-ui` to 78.1.1 and `cozy-mespapiers-lib` to 11.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "cozy-flags": "^2.9.0",
     "cozy-harvest-lib": "^9.26.6",
     "cozy-intent": "^1.17.3",
-    "cozy-mespapiers-lib": "^11.0.0",
+    "cozy-mespapiers-lib": "^11.0.4",
     "cozy-notifications": "^0.13.2",
     "cozy-realtime": "4.2.2",
     "cozy-scripts": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "cozy-realtime": "4.2.2",
     "cozy-scripts": "6.3.0",
     "cozy-sharing": "4.3.1",
-    "cozy-ui": "^78.0.0",
+    "cozy-ui": "^78.1.1",
     "date-fns": "2.29.3",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5264,10 +5264,10 @@ cozy-ui@35.22.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@^78.0.0:
-  version "78.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-78.0.0.tgz#3109d83f7f288c738e48f8e93de0eedac5c3f697"
-  integrity sha512-2q+TIWcCpXo57gtmIac4NeNePDJaJcyOUTWqczPnopgzXrd0D1oKOuuULnOoWiun7+6becpviPeutuxo4WBGIw==
+cozy-ui@^78.1.1:
+  version "78.1.1"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-78.1.1.tgz#cd31ccf190ae635e7126c239cdafc332d68d15c5"
+  integrity sha512-ukYPEqPZ0ttVqRVef7s0o2xWhMXoX/5VOvpbDEoebprhCo67QQ5THOImMJffgOFH5HKbemhFNZ897XlcxvoyGQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"
@@ -10763,9 +10763,9 @@ ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5107,10 +5107,10 @@ cozy-logger@^1.9.1:
     chalk "^2.4.2"
     json-stringify-safe "5.0.1"
 
-cozy-mespapiers-lib@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-mespapiers-lib/-/cozy-mespapiers-lib-11.0.0.tgz#49617adf69b635c6372167012fa32fbe876dae8d"
-  integrity sha512-1qcAZQffYvE6TGlB2h+IqKSS8zLacuZO+yFXWawHck/WngSBIdaaVlpt5p5rpRNQHb2/BZoXxCSGZ9kwqru3ZA==
+cozy-mespapiers-lib@^11.0.4:
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/cozy-mespapiers-lib/-/cozy-mespapiers-lib-11.0.4.tgz#c8badd305df537c70f5b3cbf9a45370ca5483e01"
+  integrity sha512-Iys2zM7cRcL+V/GIHE9X2uguO2Vot/B03DNgYZro8gszrK/Ri1d3QIc1R9wpOWi07w895kl4zQ8Hb8sOL8TyOQ==
   dependencies:
     "@date-io/date-fns" "1"
     "@material-ui/core" "4.12.3"


### PR DESCRIPTION
```
### ✨ Features

* Update cozy-mespapiers-lib from [11.0.0](https://github.com/cozy/cozy-libs/releases/tag/cozy-mespapiers-lib%4011.0.0) to [11.0.4](https://github.com/cozy/cozy-libs/releases/tag/cozy-mespapiers-lib%4011.0.4)
* Update cozy-ui from [78.0.0](https://github.com/cozy/cozy-ui/releases/tag/v78.0.0) to [78.1.1](https://github.com/cozy/cozy-ui/releases/tag/v78.1.1)
```
