### PR TITLE
fix: Remove layout path

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -27,7 +27,7 @@ const PaperView = props => {
 
 const AppRouter = () => {
   const routes = (
-    <Route path="/" element={<AppLayout />}>
+    <Route element={<AppLayout />}>
       <Route path="/paper/*" element={<PaperView />} />
       <Route path="*" element={<Navigate to="/paper" replace />} />
     </Route>


### PR DESCRIPTION
The layout route doesn't have a path attribute
See: https://reactrouter.com/en/main/start/concepts#pathless-routes
(Except if the child route is indexed on it)