### PR TITLE
feat: Add the subject of the expiration notification email

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2,6 +2,7 @@
   "notifications": {
     "expiration": {
       "email": {
+        "title": "Your document is about to expire",
         "appName": "Mes papiers",
         "button": "See",
         "content": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -2,6 +2,7 @@
   "notifications": {
     "expiration": {
       "email": {
+        "title": "Votre document arrive bientôt à expiration",
         "appName": "Mes papiers",
         "button": "Voir",
         "content": {

--- a/src/notifications/index.js
+++ b/src/notifications/index.js
@@ -53,12 +53,11 @@ class ExpirationNotification extends NotificationView {
     return ' '
   }
   /**
-   * Required by cozy-notifications
-   * The current version of cozy-notifications does not allow to omit these methods
+   * Subject of mail
    * @returns {string}
    */
   getTitle() {
-    return ' '
+    return this.t('notifications.expiration.email.title')
   }
 
   /**


### PR DESCRIPTION
```
### ✨ Features

* Add the subject of the expiration notification email
```

Il s'avère que la méthode `getTitle` est aussi utile pour les notification par email, c'est elle qui définie l'objet du mail.