### PR TITLE
feat: Update cozy-mespapiers-lib from `46.0.4` to `46.2.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "cozy-intent": "^2.13.0",
     "cozy-keys-lib": "^4.3.0",
     "cozy-logger": "^1.10.1",
-    "cozy-mespapiers-lib": "^46.0.4",
+    "cozy-mespapiers-lib": "^46.2.0",
     "cozy-notifications": "^0.14.0",
     "cozy-realtime": "^4.4.0",
     "cozy-sharing": "^7.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5151,10 +5151,10 @@ cozy-logger@^1.3.0:
     chalk "^2.4.2"
     json-stringify-safe "5.0.1"
 
-cozy-mespapiers-lib@^46.0.4:
-  version "46.0.4"
-  resolved "https://registry.yarnpkg.com/cozy-mespapiers-lib/-/cozy-mespapiers-lib-46.0.4.tgz#11fad972b357ecfbcebd3064c3b68dc296f548d0"
-  integrity sha512-gXTmwgpO7ulJthpBtzHSdZVPMZLyjSyG6Fbyz1IGFkCcXF9KrqiO5H4HgddpNHCYe2nGZscgmdFCYBRoao+yiQ==
+cozy-mespapiers-lib@^46.2.0:
+  version "46.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-mespapiers-lib/-/cozy-mespapiers-lib-46.2.0.tgz#79bc2076607d3396be1d439e4615e39f354e0e64"
+  integrity sha512-KM8bk9x4Y9FF4t2EuL/bzJkudmlgwYHjyVejgCvxtYaZTcJ9F6sHEsN3t6NyMw/78dKGvvlr+NwLv/5cqDm2NQ==
   dependencies:
     "@date-io/date-fns" "1"
     "@material-ui/pickers" "3.3.10"
@@ -10833,9 +10833,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
```
### ✨ Features

* Update cozy-mespapiers-lib from ^46.0.4 to ^46.1.0
  * Add expiration date and delay on stranger driver license.
  * Refactor of Steppers Dialog to use Cozy Dialog instead.
  * Change Passport & driver license illustrations
```