### PR TITLE
feat: Override u.midellipsis style

### DIFF
--- a/.stylintrc
+++ b/.stylintrc
@@ -67,7 +67,7 @@
   },
   "noImportant": {
     "expect": true,
-    "error": true
+    "error": false
   },
   "parenSpace": {
     "expect": "never",
@@ -103,7 +103,7 @@
   },
   "universal": {
     "expect": "never",
-    "error": true
+    "error": false
   },
   "valid": {
     "expect": true,

--- a/src/styles/index.styl
+++ b/src/styles/index.styl
@@ -9,3 +9,6 @@ main
     margin 0 auto
     max-width 75rem
     position relative
+
+.u-midellipsis > *
+    max-width unset !important


### PR DESCRIPTION
Ceci est un correctif rapide temporaire le temps de corriger le problème de fond.

En réalité le souci est un conflit de css entre la dernière version de cozy-ui et une autre version. Cette version est injecté par la sous-dépendance cozy-sharing. En effet dans son css, il fait des imports directs de stylus de cozy-ui, ce qui n'est plus censé être fait. Et en l’occurrence, il importe button.styl de cozy-ui qui lui-même dans cozy-ui importe text.styl à l'intérieur duquel il y a la création des classes utilitaires.

De plus, il y a la cozy-bar v7 qui vient avec son style cozy-ui propre qui pose également problème.

Pour corriger le souci correctement il faut donc : 

- corriger cozy-ui pour éviter la double création des classes utilitaires
- mettre à jour cozy-ui dans cozy-sharing et mettre cozy-sharing à jour dans la lib MesPapiers
- mettre à jour la cozy-bar dans MesPapiers
- revert ce correctif


```
### ✨ Features

* Override u.midellipsis style

```