### PR TITLE
fix: ExpirationNotification should use the "en" locale by default

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -6,5 +6,5 @@ export const JOBS_DOCTYPE = 'io.cozy.jobs'
 
 export const APP_SLUG = 'mespapiers'
 export const EXPIRATION_SERVICE_NAME = 'expiration'
-export const lang = process.env.COZY_LOCALE || 'fr'
-export const dictRequire = lang => require(`locales/${lang}`)
+export const DEFAULT_LANG = 'en'
+export const lang = process.env.COZY_LOCALE || DEFAULT_LANG

--- a/src/notifications/helpers.js
+++ b/src/notifications/helpers.js
@@ -1,10 +1,25 @@
 import logger from 'cozy-logger'
 import { initTranslation } from 'cozy-ui/transpiled/react/providers/I18n/translation'
 
-import { dictRequire, lang } from 'src/constants'
+import { DEFAULT_LANG, lang } from 'src/constants'
 import ExpirationNotification from 'src/notifications'
 
 const logService = logger.namespace('buildNotification')
+
+const dictRequire = lang => {
+  let res
+  try {
+    res = require(`locales/${lang}`)
+  } catch (error) {
+    res = require(`locales/${DEFAULT_LANG}`)
+    logService(
+      'info',
+      `The "${lang}" language can't be loaded, fallback to "${DEFAULT_LANG}" language.`
+    )
+  }
+  return res
+}
+
 const translation = initTranslation(lang, dictRequire)
 const t = translation.t.bind(translation)
 


### PR DESCRIPTION
```
### 🐛 Bug Fixes

* The expiration service crashes if the Cozy language is not supported by the application.
```