### PR TITLE
fix: Add css-modules webpack configuration

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -1,8 +1,8 @@
-const merge = require('webpack-merge')
 const VersionPlugin = require('cozy-scripts/plugins/VersionPlugin')
 
 const config = [
   require('cozy-scripts/config/webpack.bundle.default.js'),
+  require('cozy-scripts/config/webpack.config.css-modules'),
   require('./app.services')
 ]
 
@@ -43,4 +43,4 @@ const extraConfig = {
 }
 config.push(extraConfig)
 
-module.exports = [merge.apply(null, config)]
+module.exports = config


### PR DESCRIPTION
When merging the cozy-mespapiers-lib into the app, this configuration should have been added.