### PR TITLE
fix: Use contants instead of strings to list all known metadata

### DIFF
--- a/src/helpers/createPdfAndSave.js
+++ b/src/helpers/createPdfAndSave.js
@@ -61,7 +61,8 @@ export const updateMetadata = ({
       qualification: {
         ...qualification
       },
-      datetime: metadata[FILES_DOCTYPE].featureDate ?? pdfDoc.getCreationDate(),
+      datetime:
+        metadata[FILES_DOCTYPE]?.featureDate ?? pdfDoc.getCreationDate(),
       datetimeLabel: featureDate || 'datetime'
     }
   }

--- a/src/helpers/createPdfAndSave.spec.js
+++ b/src/helpers/createPdfAndSave.spec.js
@@ -92,6 +92,21 @@ describe('addCountryValueByQualification', () => {
 })
 
 describe('updateMetadata', () => {
+  it('should works without metadata', () => {
+    const result = updateMetadata({
+      metadata: {},
+      qualification: { label: 'birth_certificate' },
+      pdfDoc: mockPDFDocument
+    })
+
+    expect(result).toEqual({
+      [FILES_DOCTYPE]: {
+        qualification: { label: 'birth_certificate' },
+        datetime: 'mockDate',
+        datetimeLabel: 'datetime'
+      }
+    })
+  })
   it('should return metadata with other keys', () => {
     const result = updateMetadata({
       metadata: { [FILES_DOCTYPE]: { name: 'name' } },

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -9,6 +9,10 @@ import {
 } from 'src/constants'
 
 import { Q, fetchPolicies } from 'cozy-client'
+import {
+  KNOWN_DATE_METADATA_NAMES,
+  KNOWN_INFORMATION_METADATA_NAMES
+} from 'cozy-client/dist/models/paper'
 
 const defaultFetchPolicy = fetchPolicies.olderThan(86_400_000) // 24 hours
 
@@ -62,20 +66,10 @@ export const buildFilesQueryWithQualificationLabel = () => {
     'name',
     'mime',
     'referenced_by',
-    'metadata.country',
-    'metadata.datetime',
-    'metadata.expirationDate',
-    'metadata.issueDate',
+    ...KNOWN_DATE_METADATA_NAMES.map(x => `metadata.${x}`),
+    ...KNOWN_INFORMATION_METADATA_NAMES.map(x => `metadata.${x}`),
     'metadata.noticePeriod',
     'metadata.qualification.label',
-    'metadata.referencedDate',
-    'metadata.number',
-    'metadata.vehicle.licenseNumber',
-    'metadata.vehicle.confidentialNumber',
-    'metadata.bicNumber',
-    'metadata.contractType',
-    'metadata.refTaxIncome',
-    'metadata.netSocialAmount',
     'metadata.title',
     'metadata.version',
     'cozyMetadata.createdByApp',


### PR DESCRIPTION
```
### ✨ Features

* Use contants instead of strings to list all known metadata [6c0cec8](https://github.com/cozy/mespapiers/commit/6c0cec81791758c40f86225951d1315bfcc2d1bb)

### 🐛 Bug Fixes

* Cannot create papers without metadata [6947bcf](https://github.com/cozy/mespapiers/commit/6947bcf853ba241b6d560d61cdb0baac92d763d0)
```
