### PR TITLE
feat: Ensure the app settings document exists when the app is loaded

### DIFF
--- a/src/helpers/migration/metadata.js
+++ b/src/helpers/migration/metadata.js
@@ -27,12 +27,19 @@ const NEW_METADATA_ATTRIBUTE = 'number'
  * Fetch the io.cozy.mespapiers.settings document
  *
  * @param {import('cozy-client/types/CozyClient').default} client - The CozyClient instance
+ * @returns {Promise<object>} The io.cozy.mespapiers.settings document
  */
 export const fetchAppSetting = async client => {
   logService('info', 'Start fetchAppSetting')
   const appSettingQuery = buildAppSettingQuery()
+  const { data } = await client.query(appSettingQuery.definition)
 
-  return client.query(appSettingQuery.definition)
+  if (data.length === 0) {
+    const { data: doc } = await client.create(APP_SETTINGS_DOCTYPE, {})
+    return doc
+  }
+
+  return data[0]
 }
 
 /**
@@ -223,8 +230,7 @@ export const getFilesWithMetadata = files => {
 export const launchMetadataMigrationJob = async client => {
   try {
     logService('info', 'Start launchMetadataMigrationJob')
-    const { data } = await fetchAppSetting(client)
-    const settings = data?.[0] || {}
+    const settings = await fetchAppSetting(client)
 
     if (
       settings?.lastRunningMigrateMetadataService &&

--- a/src/targets/services/metadataMigration.js
+++ b/src/targets/services/metadataMigration.js
@@ -38,8 +38,7 @@ export const migrateMetadata = async () => {
   logService('info', 'Start metadata migration service')
   const client = CozyClient.fromEnv(process.env, { schema })
 
-  const filesSettings = await fetchAppSetting(client)
-  const appSettings = filesSettings?.data?.[0]
+  const appSettings = await fetchAppSetting(client)
   let lastProcessedFileDate = null
   let lastRunningMigrateMetadataService = null
 


### PR DESCRIPTION
In the case of first-time users, some functions need this document to work properly, so we need to make sure it exists.

We've had this regression since the removal of the onboarding screen, which took care of this among other things.(cozy/cozy-libs@a5e7d28)

To clarify, each time the app is loaded (new or reloaded), the `metadataMigration` job is created  if never created during the day.
This job ends up updating the document(creating it if it doesn't exist), but as the jobs are not synchronous, the problem of the missing document exists.

```
### 🐛 Bug Fixes

* Ensure the app settings document exists when the app is loaded
```
