### PR TITLE
fix(NoteDialog): Note creation returns a 404 when trying to save

### DIFF
--- a/src/components/ModelSteps/NoteDialog.jsx
+++ b/src/components/ModelSteps/NoteDialog.jsx
@@ -30,7 +30,7 @@ const NoteDialog = ({ onClose, onBack }) => {
     )
     const { data: fileCreated } = await saveFileQualification(
       client,
-      data,
+      data[0],
       qualification
     )
     const normalizedFile = normalize(fileCreated)


### PR DESCRIPTION
Following this commit a4ca8c1, the request always returns the `io.cozy.files` in an array.
The modification of this return has been forgotten here.
All these uses are now corrected.