### PR TITLE
fix(OCR): Set metadata in the correct place

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "cozy-notifications": "^0.15.0",
     "cozy-realtime": "^5.0.0",
     "cozy-sharing": "^15.0.0",
-    "cozy-ui": "^110.5.0",
+    "cozy-ui": "^110.7.0",
     "date-fns": "2.23.0",
     "flexsearch": "0.7.31",
     "leaflet": "1.7.1",

--- a/src/components/ModelSteps/ScanResult/OcrProcessingDialog.jsx
+++ b/src/components/ModelSteps/ScanResult/OcrProcessingDialog.jsx
@@ -1,4 +1,3 @@
-import merge from 'lodash/merge'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
 import OcrProcessingIcon from 'src/assets/images/OcrProcessing.svg'
@@ -10,8 +9,10 @@ import {
   getDefaultSelectedVersion,
   getFormDataFilesForOcr,
   getOcrFromFlagship,
-  makeMetadataFromOcr
+  makeMetadataFromOcr,
+  normalizeFormdataMetadata
 } from 'src/components/ModelSteps/helpers'
+import { FILES_DOCTYPE } from 'src/constants'
 
 import { useWebviewIntent } from 'cozy-intent'
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
@@ -62,7 +63,12 @@ const OcrProcessingDialog = ({ onBack, rotatedFile }) => {
       )
 
       const metadataFromOcr = makeMetadataFromOcr(attributesFound)
-      setFormData(prev => merge({}, prev, { metadata: metadataFromOcr }))
+      const newFormData = normalizeFormdataMetadata({
+        formData,
+        newMetadata: metadataFromOcr,
+        doctype: FILES_DOCTYPE
+      })
+      setFormData(newFormData)
 
       nextStep()
     }

--- a/src/components/ModelSteps/ScanResult/ScanResultDialog.spec.jsx
+++ b/src/components/ModelSteps/ScanResult/ScanResultDialog.spec.jsx
@@ -9,7 +9,10 @@ import {
   useStepperDialog
 } from 'src/components/Contexts/StepperDialogProvider'
 import ScanResultDialog from 'src/components/ModelSteps/ScanResult/ScanResultDialog'
-import { getAttributesFromOcr } from 'src/components/ModelSteps/helpers'
+import {
+  getAttributesFromOcr,
+  makeMetadataFromOcr
+} from 'src/components/ModelSteps/helpers'
 import { FLAGSHIP_SCAN_TEMP_FILENAME } from 'src/constants'
 import { isFlagshipOCRAvailable } from 'src/helpers/isFlagshipOCRAvailable'
 import AppLike from 'test/components/AppLike'
@@ -60,6 +63,7 @@ const setup = ({
   mockIsFlagshipOCRAvailable = false,
   mockGetAttributesFromOcr = jest.fn()
 } = {}) => {
+  makeMetadataFromOcr.mockReturnValue({})
   getAttributesFromOcr.mockImplementation(mockGetAttributesFromOcr)
   isFlagshipOCRAvailable.mockReturnValue(mockIsFlagshipOCRAvailable)
   useStepperDialog.mockReturnValue({

--- a/yarn.lock
+++ b/yarn.lock
@@ -5679,10 +5679,10 @@ cozy-tsconfig@1.2.0:
   resolved "https://registry.yarnpkg.com/cozy-tsconfig/-/cozy-tsconfig-1.2.0.tgz#17e61f960f139fae4d26cbac2254b9ab632b269e"
   integrity sha512-TRHnY9goF3FzVlUbP7BcHxuN2XAA4AmppT4fHHZmTKaSwYTByVR1Al+riFMDbce94kJZ1wzl9WNLWQuqzGZ6Cw==
 
-cozy-ui@^110.5.0:
-  version "110.5.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-110.5.0.tgz#fd3def80c2aa83eede7a64cd7a85214403e97b6e"
-  integrity sha512-uegFpeJ8/FcdLCS13Vlo1Oi4dTX0WUvtO9yW9nxlNL/W/yHiMsiTHHVGxLDg3kSd8PX/Mq7yhfk3Bx3k0Wf3eg==
+cozy-ui@^110.7.0:
+  version "110.7.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-110.7.0.tgz#aaceb271a651add43cb7234bfc17f49e3f0f68aa"
+  integrity sha512-IOhYWHYEphxk/AvpfCfK23Z7fAB4ZNhUMJxd1D8C/HYwgOWSP8AaPB+VWOVIJoPof3xzopGdarAZMpaitWhXpA==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"


### PR DESCRIPTION
Following the modification to handle "deep" metadata (5ae2469).

```
### 🐛 Bug Fixes

* Set OCR metadata in the right place

### 🔧 Tech

* Upgrade cozy-ui from `110.5.0` to `110.7.0`
```