### PR TITLE
fix: Style of InformationEdit Dialog

### DIFF
--- a/src/components/Views/InformationEdit.jsx
+++ b/src/components/Views/InformationEdit.jsx
@@ -23,6 +23,9 @@ import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
+// Keep the Dialog above the Viewer
+const fixedDialogStyle = { zIndex: 'var(--zIndex-modal-footer)' }
+
 const InformationEdit = () => {
   const { fileId } = useParams()
   const client = useClient()
@@ -109,6 +112,7 @@ const InformationEdit = () => {
     <FixedDialog
       open
       onClose={onClose}
+      style={fixedDialogStyle}
       title={dialogTitle}
       content={
         <div


### PR DESCRIPTION
If it is displayed directly when the page is loaded, the parent modal (Viewer), being async,
appears after and therefore above of it.