### PR TITLE
fix: Paper creation from the Cozy

### DIFF
--- a/src/helpers/createPdfAndSave.js
+++ b/src/helpers/createPdfAndSave.js
@@ -101,8 +101,9 @@ export const createPdfAndSave = async ({
   // Created first document of PDFDocument
   let pdfDoc = isAlreadyPDFDoc ? data[0].file : await PDFDocument.create()
 
+  // On Firefox, the lastModifiedDate doesn't exist, prefer the lastModified attribute
   const datetime = isAlreadyPDFDoc
-    ? pdfDoc.lastModifiedDate.toISOString()
+    ? new Date(pdfDoc.lastModified).toISOString()
     : pdfDoc.getCreationDate()
 
   // If present, we wish to keep the value in the metadata as a priority (e.g. foreign driver's license).

--- a/src/helpers/createPdfAndSave.spec.js
+++ b/src/helpers/createPdfAndSave.spec.js
@@ -65,7 +65,6 @@ describe('createAndSavePdf', () => {
     const filePDF = new File(['bob'], 'bob.pdf', {
       type: 'application/pdf'
     })
-    filePDF.lastModifiedDate = new Date()
     const fileJPG = new File(['bob'], 'bob.jpg', {
       type: 'image/jpg'
     })


### PR DESCRIPTION
“File” doesn't have exactly the same attributes between Chrome and Firefox!
In this case, we were using the `lastModifiedDate` attribute, but it doesn't exist on Firefox.
