### PR TITLE
fix: Color scheme was missing in for intents

### DIFF
--- a/src/targets/intents/index.ejs
+++ b/src/targets/intents/index.ejs
@@ -8,6 +8,7 @@
   <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
   <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
   <meta name="theme-color" content="#ffffff">
+  <meta name="color-scheme" content="light dark" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" type="text/css" href="//{{.Domain}}/assets/fonts/fonts.css">
   <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>


### PR DESCRIPTION
and so the wrong color scheme was applied in dark mode, resulting to white background instead of transparent.

For information, here's an interesting article https://fvsch.com/transparent-iframes